### PR TITLE
Implement adaptive learning engine and audit tooling

### DIFF
--- a/lib/adaptiveQueue.ts
+++ b/lib/adaptiveQueue.ts
@@ -1,0 +1,28 @@
+import { Question, QuestionProgress } from '@prisma/client';
+
+export interface PriorityContext {
+  question: Question;
+  progress?: QuestionProgress;
+}
+
+export function calculateAccuracy(progress?: QuestionProgress): number {
+  if (!progress || progress.attempts === 0) {
+    return 0;
+  }
+  return progress.correct / progress.attempts;
+}
+
+export function calculatePriorityScore(context: PriorityContext): number {
+  const accuracy = calculateAccuracy(context.progress);
+  const streak = context.progress?.streak ?? 0;
+  const difficulty = context.question.difficulty;
+  const score = (1 - accuracy) * 0.6 + (1 / (streak + 1)) * 0.2 + difficulty * 0.2;
+  return Number(score.toFixed(6));
+}
+
+export function isDueForReview(progress: QuestionProgress | undefined, now: Date): boolean {
+  if (!progress || !progress.nextReview) {
+    return true;
+  }
+  return progress.nextReview.getTime() <= now.getTime();
+}

--- a/lib/progressModel.ts
+++ b/lib/progressModel.ts
@@ -1,0 +1,75 @@
+import { PrismaClient, LearningQueueEntry, Question, QuestionProgress } from '@prisma/client';
+
+export interface QuestionWithProgress extends Question {
+  progress?: QuestionProgress;
+}
+
+export interface ProgressModel {
+  getQuestionsWithProgress(userId: string): Promise<QuestionWithProgress[]>;
+  upsertProgress(
+    userId: string,
+    questionId: string,
+    updates: Partial<QuestionProgress>,
+  ): Promise<QuestionProgress>;
+  updateQuestionDifficulty(questionId: string, difficulty: number): Promise<Question>;
+  upsertQueueEntry(userId: string, questionId: string, priorityScore: number): Promise<LearningQueueEntry>;
+}
+
+export class PrismaProgressModel implements ProgressModel {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async getQuestionsWithProgress(userId: string): Promise<QuestionWithProgress[]> {
+    const questions = await this.prisma.question.findMany({
+      include: {
+        progress: {
+          where: { userId },
+        },
+      },
+    });
+
+    return questions.map((question) => ({
+      ...question,
+      progress: question.progress[0],
+    }));
+  }
+
+  async upsertProgress(
+    userId: string,
+    questionId: string,
+    updates: Partial<QuestionProgress>,
+  ): Promise<QuestionProgress> {
+    return this.prisma.questionProgress.upsert({
+      where: { userId_questionId: { userId, questionId } },
+      update: { ...updates },
+      create: {
+        userId,
+        questionId,
+        attempts: updates.attempts ?? 0,
+        correct: updates.correct ?? 0,
+        streak: updates.streak ?? 0,
+        weight: updates.weight ?? 1,
+        nextReview: updates.nextReview ?? null,
+        lastAnswered: updates.lastAnswered ?? null,
+      },
+    });
+  }
+
+  async updateQuestionDifficulty(questionId: string, difficulty: number): Promise<Question> {
+    return this.prisma.question.update({
+      where: { id: questionId },
+      data: { difficulty },
+    });
+  }
+
+  async upsertQueueEntry(
+    userId: string,
+    questionId: string,
+    priorityScore: number,
+  ): Promise<LearningQueueEntry> {
+    return this.prisma.learningQueueEntry.upsert({
+      where: { userId_questionId: { userId, questionId } },
+      update: { priorityScore },
+      create: { userId, questionId, priorityScore },
+    });
+  }
+}

--- a/lib/questionEngine.ts
+++ b/lib/questionEngine.ts
@@ -1,0 +1,104 @@
+import { PrismaClient, QuestionProgress } from '@prisma/client';
+import { calculatePriorityScore, isDueForReview } from './adaptiveQueue.js';
+import { PrismaProgressModel, ProgressModel, QuestionWithProgress } from './progressModel.js';
+
+export interface SelectedQuestion {
+  question: QuestionWithProgress;
+  priorityScore: number;
+}
+
+export interface QuestionEngineOptions {
+  prisma?: PrismaClient;
+  progressModel?: ProgressModel;
+  now?: () => Date;
+}
+
+export class QuestionEngine {
+  private readonly progressModel: ProgressModel;
+  private readonly now: () => Date;
+
+  constructor(options: QuestionEngineOptions = {}) {
+    this.now = options.now ?? (() => new Date());
+    if (options.progressModel) {
+      this.progressModel = options.progressModel;
+    } else if (options.prisma) {
+      this.progressModel = new PrismaProgressModel(options.prisma);
+    } else {
+      throw new Error('A PrismaClient or ProgressModel must be provided.');
+    }
+  }
+
+  async getNextQuestion(userId: string): Promise<SelectedQuestion | null> {
+    const now = this.now();
+    const questions = await this.progressModel.getQuestionsWithProgress(userId);
+
+    const candidates = questions
+      .map((question) => {
+        const priorityScore = calculatePriorityScore({ question, progress: question.progress });
+        return { question, priorityScore } as SelectedQuestion;
+      })
+      .filter((candidate) => isDueForReview(candidate.question.progress, now));
+
+    if (candidates.length === 0) {
+      return null;
+    }
+
+    candidates.sort((a, b) => b.priorityScore - a.priorityScore);
+    const top = candidates[0];
+    await this.progressModel.upsertQueueEntry(userId, top.question.id, top.priorityScore);
+    return top;
+  }
+
+  async submitAnswer(userId: string, questionId: string, correct: boolean): Promise<QuestionProgress> {
+    const now = this.now();
+    const questions = await this.progressModel.getQuestionsWithProgress(userId);
+    const question = questions.find((q) => q.id === questionId);
+
+    if (!question) {
+      throw new Error(`Question ${questionId} is not available for user ${userId}.`);
+    }
+
+    const progress = question.progress;
+    const attempts = (progress?.attempts ?? 0) + 1;
+    const correctCount = (progress?.correct ?? 0) + (correct ? 1 : 0);
+    const streak = correct ? (progress?.streak ?? 0) + 1 : 0;
+    const nextReview = this.calculateNextReview(streak, now);
+    const updatedDifficulty = this.calculateDifficulty(question.difficulty, correct);
+
+    await this.progressModel.updateQuestionDifficulty(questionId, updatedDifficulty);
+
+    const updatedProgress: QuestionProgress = await this.progressModel.upsertProgress(userId, questionId, {
+      attempts,
+      correct: correctCount,
+      streak,
+      nextReview,
+      lastAnswered: now,
+    });
+
+    const priorityScore = calculatePriorityScore({
+      question: { ...question, difficulty: updatedDifficulty },
+      progress: updatedProgress,
+    });
+
+    const progressWithWeight: QuestionProgress = await this.progressModel.upsertProgress(userId, questionId, {
+      weight: priorityScore,
+    });
+
+    await this.progressModel.upsertQueueEntry(userId, questionId, priorityScore);
+
+    return progressWithWeight;
+  }
+
+  private calculateDifficulty(currentDifficulty: number, correct: boolean): number {
+    if (correct) {
+      return Math.max(currentDifficulty - 0.05, 0.1);
+    }
+    return Math.min(currentDifficulty + 0.08, 1);
+  }
+
+  private calculateNextReview(streak: number, now: Date): Date {
+    const hours = 1.5 ** streak;
+    const millis = hours * 60 * 60 * 1000;
+    return new Date(now.getTime() + millis);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,20 +7,23 @@
     "dev": "vite",
     "sync:condition-content": "ts-node ./scripts/convertMdToJson.ts",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "audit:questions": "ts-node ./scripts/auditQuestionLinks.ts"
   },
   "dependencies": {
+    "@prisma/client": "^5.22.0",
+    "@google/generative-ai": "^0.21.0",
     "remark-parse": "^11.0.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-markdown": "^9.0.0",
     "remark-gfm": "^4.0.0",
     "rehype-raw": "^7.0.0",
-    "@google/generative-ai": "^0.21.0",
     "unified": "^11.0.5",
     "mdast-util-to-string": "^4.0.0"
   },
   "devDependencies": {
+    "prisma": "^5.22.0",
     "@types/mdast": "^4.0.4",
     "@types/node": "^22.14.0",
     "@vitejs/plugin-react": "^5.0.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,57 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model Condition {
+  id        String     @id @default(uuid())
+  name      String
+  system    String
+  questions Question[]
+  @@index([name])
+}
+
+model Question {
+  id           String             @id @default(uuid())
+  conditionId  String
+  text         String
+  difficulty   Float
+  condition    Condition          @relation(fields: [conditionId], references: [id], onDelete: Cascade)
+  progress     QuestionProgress[]
+  queueEntries LearningQueueEntry[]
+
+  @@index([conditionId])
+}
+
+model QuestionProgress {
+  id           String    @id @default(uuid())
+  userId       String
+  questionId   String
+  attempts     Int       @default(0)
+  correct      Int       @default(0)
+  streak       Int       @default(0)
+  weight       Float     @default(1)
+  nextReview   DateTime?
+  lastAnswered DateTime?
+  question     Question  @relation(fields: [questionId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, questionId])
+  @@index([userId])
+}
+
+model LearningQueueEntry {
+  id            String    @id @default(uuid())
+  userId        String
+  questionId    String
+  priorityScore Float
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+  question      Question  @relation(fields: [questionId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, questionId])
+  @@index([userId])
+}

--- a/scripts/auditQuestionLinks.ts
+++ b/scripts/auditQuestionLinks.ts
@@ -1,0 +1,97 @@
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { PrismaClient } from '@prisma/client';
+
+interface AuditIssue<T> {
+  description: string;
+  items: T[];
+}
+
+interface AuditReport {
+  missingConditionId: AuditIssue<{ id: string; text: string }>;
+  invalidConditionReferences: AuditIssue<{ id: string; conditionId: string }>;
+  duplicateQuestionProgress: AuditIssue<{ questionId: string; userId: string; count: number }>;
+  conditionsWithoutQuestions: AuditIssue<{ conditionId: string; name: string }>;
+  generatedAt: string;
+}
+
+async function runAudit(): Promise<AuditReport> {
+  const prisma = new PrismaClient();
+
+  const questionsWithConditions = await prisma.question.findMany({
+    include: { condition: true },
+  });
+
+  const missingConditionId = questionsWithConditions
+    .filter((question) => !question.conditionId)
+    .map((question) => ({ id: question.id, text: question.text }));
+
+  const invalidConditionReferences = questionsWithConditions
+    .filter((question) => !question.condition)
+    .map((question) => ({ id: question.id, conditionId: question.conditionId }));
+
+  const duplicateQuestionProgress = await prisma.questionProgress.groupBy({
+    by: ['questionId', 'userId'],
+    _count: { _all: true },
+    having: {
+      _count: {
+        _all: {
+          gt: 1,
+        },
+      },
+    },
+  });
+
+  const conditionsWithoutQuestions = await prisma.condition.findMany({
+    where: {
+      questions: { none: {} },
+    },
+    select: {
+      id: true,
+      name: true,
+    },
+  });
+
+  await prisma.$disconnect();
+
+  return {
+    missingConditionId: {
+      description: 'Questions missing a conditionId value.',
+      items: missingConditionId,
+    },
+    invalidConditionReferences: {
+      description: 'Questions referencing a condition that does not exist.',
+      items: invalidConditionReferences,
+    },
+    duplicateQuestionProgress: {
+      description: 'Duplicate question progress entries detected for a user.',
+      items: duplicateQuestionProgress.map((entry) => ({
+        questionId: entry.questionId,
+        userId: entry.userId,
+        count: entry._count._all,
+      })),
+    },
+    conditionsWithoutQuestions: {
+      description: 'Conditions that are not linked to any question.',
+      items: conditionsWithoutQuestions,
+    },
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+async function writeReport(report: AuditReport): Promise<void> {
+  const outputDir = join(process.cwd(), 'output');
+  mkdirSync(outputDir, { recursive: true });
+  const outputPath = join(outputDir, 'question_audit_report.json');
+  writeFileSync(outputPath, JSON.stringify(report, null, 2));
+  // eslint-disable-next-line no-console
+  console.log(`Audit report written to ${outputPath}`);
+}
+
+runAudit()
+  .then(writeReport)
+  .catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error('Audit failed', error);
+    process.exitCode = 1;
+  });

--- a/tests/adaptive.test.ts
+++ b/tests/adaptive.test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { QuestionProgress } from '@prisma/client';
+import { calculatePriorityScore } from '../lib/adaptiveQueue.js';
+import { ProgressModel, QuestionWithProgress } from '../lib/progressModel.js';
+import { QuestionEngine } from '../lib/questionEngine.js';
+
+class InMemoryProgressModel implements ProgressModel {
+  constructor(private readonly questions: QuestionWithProgress[]) {}
+
+  async getQuestionsWithProgress(_userId: string): Promise<QuestionWithProgress[]> {
+    return this.questions;
+  }
+
+  async upsertProgress(
+    userId: string,
+    questionId: string,
+    updates: Partial<QuestionProgress>,
+  ): Promise<QuestionProgress> {
+    const target = this.questions.find((q) => q.id === questionId);
+    if (!target) throw new Error('Question not found');
+    target.progress = {
+      id: target.progress?.id ?? 'progress-' + questionId,
+      userId,
+      questionId,
+      attempts: updates?.attempts ?? target.progress?.attempts ?? 0,
+      correct: updates?.correct ?? target.progress?.correct ?? 0,
+      streak: updates?.streak ?? target.progress?.streak ?? 0,
+      weight: updates?.weight ?? target.progress?.weight ?? 1,
+      nextReview: updates?.nextReview ?? target.progress?.nextReview ?? null,
+      lastAnswered: updates?.lastAnswered ?? target.progress?.lastAnswered ?? null,
+    };
+    return target.progress;
+  }
+
+  async updateQuestionDifficulty(questionId: string, difficulty: number) {
+    const target = this.questions.find((q) => q.id === questionId);
+    if (!target) throw new Error('Question not found');
+    target.difficulty = difficulty;
+    return target;
+  }
+
+  async upsertQueueEntry(userId: string, questionId: string, priorityScore: number) {
+    return {
+      id: 'queue',
+      userId,
+      questionId,
+      priorityScore,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+  }
+}
+
+test('calculatePriorityScore favors lower accuracy and streak', () => {
+  const question = { id: 'q1', conditionId: 'c1', text: 'text', difficulty: 0.5 } as QuestionWithProgress;
+  const score = calculatePriorityScore({ question });
+  assert.equal(score, 0.9);
+});
+
+test('QuestionEngine returns the highest priority due question', async () => {
+  const now = new Date('2024-01-01T00:00:00Z');
+  const questions: QuestionWithProgress[] = [
+    {
+      id: 'question-1',
+      conditionId: 'cond-1',
+      text: 'Q1',
+      difficulty: 0.2,
+      progress: {
+        id: 'p1',
+        userId: 'user-1',
+        questionId: 'question-1',
+        attempts: 5,
+        correct: 4,
+        streak: 3,
+        weight: 1,
+        nextReview: now,
+        lastAnswered: now,
+      },
+    },
+    {
+      id: 'question-2',
+      conditionId: 'cond-1',
+      text: 'Q2',
+      difficulty: 0.8,
+      progress: {
+        id: 'p2',
+        userId: 'user-1',
+        questionId: 'question-2',
+        attempts: 1,
+        correct: 0,
+        streak: 0,
+        weight: 1,
+        nextReview: now,
+        lastAnswered: now,
+      },
+    },
+  ];
+
+  const engine = new QuestionEngine({
+    progressModel: new InMemoryProgressModel(questions),
+    now: () => now,
+  });
+
+  const selected = await engine.getNextQuestion('user-1');
+  assert.ok(selected);
+  assert.equal(selected?.question.id, 'question-2');
+});
+
+test('submitAnswer updates streak, difficulty, and weight', async () => {
+  const now = new Date('2024-01-01T00:00:00Z');
+  const questions: QuestionWithProgress[] = [
+    {
+      id: 'question-1',
+      conditionId: 'cond-1',
+      text: 'Q1',
+      difficulty: 0.5,
+      progress: undefined,
+    },
+  ];
+
+  const progressModel = new InMemoryProgressModel(questions);
+  const engine = new QuestionEngine({ progressModel, now: () => now });
+
+  const result = await engine.submitAnswer('user-1', 'question-1', true);
+  assert.equal(result.attempts, 1);
+  assert.equal(result.correct, 1);
+  assert.equal(result.streak, 1);
+  assert.ok(result.nextReview);
+  assert.equal(questions[0].difficulty, 0.45);
+  assert.equal(result.weight, calculatePriorityScore({
+    question: questions[0],
+    progress: result,
+  }));
+});


### PR DESCRIPTION
## Summary
- define Prisma schema for conditions, questions, progress, and learning queue to support adaptive spaced repetition
- implement adaptive queue scoring, progress persistence, and question engine workflows with difficulty adjustments
- add referential integrity audit script and unit tests for the adaptive selection and answer submission logic

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692539c233d0832a928f3a29165c4a0d)