### PR TITLE
Use generated condition dataset for condition pages

### DIFF
--- a/components/ConditionDetailModal.tsx
+++ b/components/ConditionDetailModal.tsx
@@ -2,16 +2,16 @@
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
-  CONDITION_CONTENT,
-  type ConditionContent,
-} from "../src/conditionContent.generated";
-import {
   buildConditionDefinition,
   type ConditionMeta,
 } from "../conditionRegistry";
+import {
+  getConditionById,
+  isMeaningfulContent,
+  type ConditionEntry,
+} from "../lib/loadConditions";
 import ConditionSidebar from "./ConditionSidebar";
-import type { BulletNode, ParsedSection, TextPart } from "../services/markdownParser";
-import { buildParsedSections } from "../services/markdownParser";
+import FormattedSection from "./conditions/FormattedSection";
 
 interface ConditionDetailModalProps {
   condition: ConditionMeta;
@@ -22,55 +22,25 @@ interface ConditionDetailModalProps {
 interface ContentSection {
   key: string;
   title: string;
-  type: "markdown" | "list";
-  value?: string;
-  items?: string[];
+  content?: string;
   accent?: "danger" | "default";
 }
 
-const renderParts = (parts: TextPart[]) =>
-  parts.map((part, index) => {
-    if (part.type === "strong") {
-      return (
-        <strong key={`${part.value}-${index}`} className="condition-strong">
-          {part.value}
-        </strong>
-      );
-    }
-
-    if (part.type === "em") {
-      return (
-        <em key={`${part.value}-${index}`} className="condition-emphasis">
-          {part.value}
-        </em>
-      );
-    }
-
-    return <React.Fragment key={`${part.value}-${index}`}>{part.value}</React.Fragment>;
-  });
-
-const BulletedList: React.FC<{ items: BulletNode[]; level?: number }> = ({
-  items,
-  level = 0,
-}) => {
-  if (!items.length) return null;
-
-  return (
-    <ul className={`condition-bullet-list level-${level}`}>
-      {items.map((item, index) => (
-        <li
-          key={`${level}-${index}-${item.parts.map((p) => p.value).join("-")}`}
-          className="condition-bullet-item"
-        >
-          <span className="condition-bullet-text">{renderParts(item.parts)}</span>
-          {item.children.length > 0 && (
-            <BulletedList items={item.children} level={Math.min(level + 1, 2)} />
-          )}
-        </li>
-      ))}
-    </ul>
-  );
-};
+const SECTION_ORDER: { key: string; title: string; accent?: "danger" | "default" }[] = [
+  { key: "overview", title: "Overview" },
+  { key: "etiology", title: "Etiology" },
+  { key: "epidemiology", title: "Epidemiology" },
+  { key: "riskFactors", title: "Risk Factors" },
+  { key: "clinicalPresentation", title: "Clinical Presentation" },
+  { key: "physicalExam", title: "Physical Exam" },
+  { key: "diagnostics", title: "Diagnostics" },
+  { key: "differentialDiagnosis", title: "Differential Diagnosis" },
+  { key: "management", title: "Management" },
+  { key: "treatment", title: "Treatment" },
+  { key: "complications", title: "Complications" },
+  { key: "prognosis", title: "Prognosis" },
+  { key: "preventionEducation", title: "Prevention & Education" },
+];
 
 const ConditionDetailModal: React.FC<ConditionDetailModalProps> = ({
   condition,
@@ -78,7 +48,7 @@ const ConditionDetailModal: React.FC<ConditionDetailModalProps> = ({
   onDrillCondition,
 }) => {
   const [mediaIndex, setMediaIndex] = useState(0);
-  const [activeSection, setActiveSection] = useState<string>("overview");
+  const [activeSection, setActiveSection] = useState<string>("");
   const contentRef = useRef<HTMLDivElement | null>(null);
   const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
 
@@ -87,128 +57,18 @@ const ConditionDetailModal: React.FC<ConditionDetailModalProps> = ({
     [condition]
   );
 
-  const content: ConditionContent = useMemo(() => {
-    return (
-      CONDITION_CONTENT[conditionId] ||
-      CONDITION_CONTENT[condition.condition] ||
-      {}
-    );
+  const content: ConditionEntry | undefined = useMemo(() => {
+    return getConditionById(conditionId) ?? getConditionById(condition.condition);
   }, [condition.condition, conditionId]);
 
   const sections: ContentSection[] = useMemo(() => {
-    return [
-      {
-        key: "overview",
-        title: "Overview",
-        type: "markdown",
-        value: content.overview,
-      },
-      {
-        key: "etiologyPathophysiology",
-        title: "Etiology & Pathophysiology",
-        type: "markdown",
-        value: content.etiologyPathophysiology,
-      },
-      {
-        key: "epidemiology",
-        title: "Epidemiology",
-        type: "markdown",
-        value: content.epidemiology,
-      },
-      {
-        key: "clinicalPresentation",
-        title: "Clinical Presentation",
-        type: "markdown",
-        value: content.clinicalPresentation,
-      },
-      {
-        key: "diagnostics",
-        title: "Diagnostics",
-        type: "markdown",
-        value: content.diagnostics?.notes,
-      },
-      {
-        key: "riskFactors",
-        title: "Risk Factors",
-        type: "list",
-        items: Array.isArray(content.riskFactors)
-          ? content.riskFactors
-          : undefined,
-      },
-      {
-        key: "symptoms",
-        title: "Symptoms",
-        type: "list",
-        items: Array.isArray(content.symptoms) ? content.symptoms : undefined,
-      },
-      {
-        key: "examFindings",
-        title: "Exam Findings",
-        type: "list",
-        items: Array.isArray(content.examFindings)
-          ? content.examFindings
-          : undefined,
-      },
-      {
-        key: "keyPoints",
-        title: "Key Points",
-        type: "list",
-        items: Array.isArray(content.keyPoints) ? content.keyPoints : undefined,
-      },
-      {
-        key: "redFlags",
-        title: "Red Flags",
-        type: "list",
-        items: Array.isArray(content.redFlags) ? content.redFlags : undefined,
-        accent: "danger",
-      },
-      {
-        key: "treatmentPearls",
-        title: "Treatment Pearls",
-        type: "list",
-        items: Array.isArray(content.treatmentPearls)
-          ? content.treatmentPearls
-          : undefined,
-      },
-      {
-        key: "treatment",
-        title: "Treatment",
-        type: "list",
-        items: Array.isArray(content.treatment) ? content.treatment : undefined,
-      },
-      {
-        key: "management",
-        title: "Management",
-        type: "list",
-        items: Array.isArray(content.management) ? content.management : undefined,
-      },
-      {
-        key: "complications",
-        title: "Complications",
-        type: "list",
-        items: Array.isArray(content.complications)
-          ? content.complications
-          : undefined,
-      },
-      {
-        key: "prognosis",
-        title: "Prognosis",
-        type: "markdown",
-        value: content.prognosis,
-      },
-    ].filter((section) => {
-      if (section.type === "markdown") {
-        return !!section.value;
-      }
+    if (!content?.sections) return [];
 
-      return (section.items?.length ?? 0) > 0;
-    });
-  }, [content]);
-
-  const parsedSections: ParsedSection[] = useMemo(
-    () => buildParsedSections(sections),
-    [sections]
-  );
+    return SECTION_ORDER.map((config) => ({
+      ...config,
+      content: content.sections?.[config.key],
+    })).filter((section) => isMeaningfulContent(section.content));
+  }, [content?.sections]);
 
   useEffect(() => {
     document.body.style.overflow = "hidden";
@@ -219,7 +79,7 @@ const ConditionDetailModal: React.FC<ConditionDetailModalProps> = ({
 
   useEffect(() => {
     const container = contentRef.current;
-    if (!container || parsedSections.length === 0) return;
+    if (!container || sections.length === 0) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -234,8 +94,8 @@ const ConditionDetailModal: React.FC<ConditionDetailModalProps> = ({
       { root: container, threshold: [0.2, 0.45, 0.65], rootMargin: "0px 0px -25% 0px" }
     );
 
-    parsedSections.forEach((section) => {
-      const target = sectionRefs.current[section.id];
+    sections.forEach((section) => {
+      const target = sectionRefs.current[section.key];
       if (target) observer.observe(target);
     });
 
@@ -244,10 +104,10 @@ const ConditionDetailModal: React.FC<ConditionDetailModalProps> = ({
       const bottomGap =
         container.scrollHeight - (scrollTop + container.clientHeight);
 
-      if (scrollTop <= 5 && parsedSections.length > 0) {
-        setActiveSection(parsedSections[0].id);
-      } else if (bottomGap <= 5 && parsedSections.length > 0) {
-        setActiveSection(parsedSections[parsedSections.length - 1].id);
+      if (scrollTop <= 5 && sections.length > 0) {
+        setActiveSection(sections[0].key);
+      } else if (bottomGap <= 5 && sections.length > 0) {
+        setActiveSection(sections[sections.length - 1].key);
       }
     };
 
@@ -258,10 +118,16 @@ const ConditionDetailModal: React.FC<ConditionDetailModalProps> = ({
       observer.disconnect();
       container.removeEventListener("scroll", handleEdges);
     };
-  }, [parsedSections]);
+  }, [sections]);
 
-  const mediaIds = content.mediaIds ?? [];
-  const hasAnyContent = parsedSections.length > 0;
+  useEffect(() => {
+    if (sections.length > 0) {
+      setActiveSection(sections[0].key);
+    }
+  }, [sections]);
+
+  const mediaIds: string[] = [];
+  const hasAnyContent = sections.length > 0;
 
   const scrollToSection = (key: string) => {
     const container = contentRef.current;
@@ -291,8 +157,8 @@ const ConditionDetailModal: React.FC<ConditionDetailModalProps> = ({
 
         <div className="condition-layout">
           <ConditionSidebar
-            sections={parsedSections.map((section) => ({
-              key: section.id,
+            sections={sections.map((section) => ({
+              key: section.key,
               title: section.title,
             }))}
             activeSection={activeSection}
@@ -356,12 +222,12 @@ const ConditionDetailModal: React.FC<ConditionDetailModalProps> = ({
               )}
 
               <div className="condition-sections">
-                {parsedSections.map((section) => (
+                {sections.map((section) => (
                   <section
-                    key={section.id}
-                    id={section.id}
+                    key={section.key}
+                    id={section.key}
                     ref={(el) => {
-                      sectionRefs.current[section.id] = el;
+                      sectionRefs.current[section.key] = el;
                     }}
                     className="condition-card scroll-mt-24"
                   >
@@ -371,13 +237,7 @@ const ConditionDetailModal: React.FC<ConditionDetailModalProps> = ({
                         section.accent === "danger" ? "condition-content-danger" : ""
                       }`}
                     >
-                      {section.bullets.length > 0 ? (
-                        <BulletedList items={section.bullets} />
-                      ) : (
-                        <p className="condition-empty">
-                          Detailed notes for this condition haven&apos;t been added yet.
-                        </p>
-                      )}
+                      <FormattedSection content={section.content} />
                     </div>
                   </section>
                 ))}

--- a/components/conditions/FormattedSection.tsx
+++ b/components/conditions/FormattedSection.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import { isMeaningfulContent } from "../../lib/loadConditions";
+
+interface BulletNode {
+  parts: React.ReactNode[];
+  children: BulletNode[];
+}
+
+const BULLET_LEVEL_BY_SYMBOL: Record<string, number> = {
+  "•": 0,
+  "◦": 1,
+  "▪": 2,
+};
+
+function toBoldParts(text: string): React.ReactNode[] {
+  const parts: React.ReactNode[] = [];
+  const boldPattern = /\*\*([^*]+)\*\*/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = boldPattern.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index));
+    }
+    parts.push(<strong key={`${match[1]}-${match.index}`}>{match[1]}</strong>);
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+
+  return parts;
+}
+
+function buildBulletTree(content: string): BulletNode[] {
+  const lines = content.replace(/\r\n/g, "\n").split("\n");
+  const roots: BulletNode[] = [];
+  const stack: { level: number; node: BulletNode }[] = [];
+
+  lines.forEach((line) => {
+    if (!line.trim()) return;
+
+    const match = line.match(/^(\s*)([•◦▪])?\s*(.*)$/);
+    const leadingSpaces = match?.[1]?.length ?? 0;
+    const bulletSymbol = match?.[2] ?? "";
+    const text = (match?.[3] ?? line).trim();
+    if (!text) return;
+
+    const levelFromSymbol = BULLET_LEVEL_BY_SYMBOL[bulletSymbol];
+    const levelFromIndent = Math.floor(leadingSpaces / 4);
+    const level = Math.min(
+      2,
+      Number.isFinite(levelFromSymbol)
+        ? (levelFromSymbol as number)
+        : levelFromIndent
+    );
+
+    while (stack.length && stack[stack.length - 1].level >= level) {
+      stack.pop();
+    }
+
+    const node: BulletNode = { parts: toBoldParts(text), children: [] };
+    const parent = stack.findLast((entry) => entry.level < level);
+
+    if (parent) {
+      parent.node.children.push(node);
+    } else {
+      roots.push(node);
+    }
+
+    stack.push({ level, node });
+  });
+
+  return roots;
+}
+
+const BulletList: React.FC<{ nodes: BulletNode[]; level: number }> = ({
+  nodes,
+  level,
+}) => {
+  if (!nodes.length) return null;
+
+  return (
+    <ul className={`condition-bullet-list level-${level}`}>
+      {nodes.map((node, index) => (
+        <li key={`${level}-${index}`} className="condition-bullet-item">
+          <span className="condition-bullet-text">{node.parts}</span>
+          {node.children.length > 0 && (
+            <BulletList
+              nodes={node.children}
+              level={Math.min(level + 1, 2)}
+            />
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+interface FormattedSectionProps {
+  content?: string | null;
+}
+
+const FormattedSection: React.FC<FormattedSectionProps> = ({ content }) => {
+  if (!isMeaningfulContent(content)) return null;
+
+  const bullets = buildBulletTree(content ?? "");
+
+  if (bullets.length === 0) {
+    return <p className="condition-empty">No details available for this section.</p>;
+  }
+
+  return <BulletList nodes={bullets} level={0} />;
+};
+
+export default FormattedSection;

--- a/lib/loadConditions.ts
+++ b/lib/loadConditions.ts
@@ -1,0 +1,49 @@
+import conditions from "../conditionContent.generated.json";
+
+export interface ConditionSections {
+  [sectionKey: string]: string;
+}
+
+export interface ConditionEntry {
+  condition: string;
+  sections: ConditionSections;
+}
+
+const PLACEHOLDER_TEXT = "[NO CONTENT PROVIDED]";
+
+function normalizeEntry(raw: unknown, id: string): ConditionEntry | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const entry = raw as { condition?: unknown; sections?: unknown };
+
+  const conditionId =
+    typeof entry.condition === "string" && entry.condition.trim().length > 0
+      ? entry.condition
+      : id;
+
+  const rawSections = entry.sections;
+  const sections: ConditionSections =
+    rawSections && typeof rawSections === "object"
+      ? (rawSections as ConditionSections)
+      : {};
+
+  return { condition: conditionId, sections };
+}
+
+export const CONDITIONS = Object.fromEntries(
+  Object.entries(conditions as Record<string, unknown>).map(([id, raw]) => [
+    id,
+    normalizeEntry(raw, id),
+  ])
+) as Record<string, ConditionEntry | undefined>;
+
+export function isMeaningfulContent(value?: string | null): boolean {
+  if (!value) return false;
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (!normalized) return false;
+  return normalized.toUpperCase() !== PLACEHOLDER_TEXT;
+}
+
+export function getConditionById(id: string): ConditionEntry | undefined {
+  if (!id || typeof id !== "string") return undefined;
+  return normalizeEntry((conditions as Record<string, unknown>)[id], id);
+}

--- a/pages/conditions/[id].tsx
+++ b/pages/conditions/[id].tsx
@@ -1,0 +1,68 @@
+import React, { useMemo } from "react";
+import FormattedSection from "../../components/conditions/FormattedSection";
+import {
+  getConditionById,
+  isMeaningfulContent,
+  type ConditionEntry,
+} from "../../lib/loadConditions";
+
+const getConditionIdFromPath = (): string => {
+  if (typeof window === "undefined") return "";
+  const parts = window.location.pathname.split("/").filter(Boolean);
+  return decodeURIComponent(parts[parts.length - 1] ?? "");
+};
+
+const formatSectionTitle = (key: string): string => {
+  return key
+    .replace(/([A-Z])/g, " $1")
+    .replace(/_/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^./, (char) => char.toUpperCase());
+};
+
+const ConditionPage: React.FC = () => {
+  const conditionId = useMemo(() => getConditionIdFromPath(), []);
+  const conditionContent: ConditionEntry | undefined = useMemo(
+    () => (conditionId ? getConditionById(conditionId) : undefined),
+    [conditionId]
+  );
+
+  const sections = useMemo(() => {
+    const entries = conditionContent?.sections ?? {};
+    return Object.entries(entries)
+      .filter(([, value]) => isMeaningfulContent(value))
+      .map(([key, value]) => ({ key, value, title: formatSectionTitle(key) }));
+  }, [conditionContent?.sections]);
+
+  return (
+    <main className="condition-page">
+      <header className="condition-modal-header">
+        <div>
+          <h2 className="condition-title">
+            {conditionContent?.condition ?? "Condition not found"}
+          </h2>
+        </div>
+      </header>
+
+      <div className="condition-sections">
+        {sections.length === 0 && (
+          <p className="condition-empty">
+            Condition content isn&apos;t available for this entry.
+          </p>
+        )}
+
+        {sections.map((section) => (
+          <section key={section.key} className="condition-card">
+            <h3 className="condition-section-title">{section.title}</h3>
+            <div className="condition-content">
+              <FormattedSection content={section.value} />
+            </div>
+          </section>
+        ))}
+      </div>
+    </main>
+  );
+};
+
+export default ConditionPage;

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -19,7 +19,7 @@ import {
   findConditionMeta,
   type ConditionMeta,
 } from "../conditionRegistry";
-import { CONDITION_CONTENT } from "../src/conditionContent.generated";
+import { getConditionById, isMeaningfulContent } from "../lib/loadConditions";
 
 // --- Helper: call Netlify serverless function, which talks to Gemini ---
 
@@ -62,20 +62,24 @@ const slugify = (value: string): string =>
 
 function getConditionRegistryContext(meta: ConditionMeta): string | undefined {
   const id = buildConditionDefinition(meta).id;
-  const content = CONDITION_CONTENT[id];
+  const content = getConditionById(id)?.sections;
   if (!content) return undefined;
 
   const pieces: string[] = [];
-  if (content.overview) pieces.push(`Overview: ${content.overview}`);
-  if (content.etiologyPathophysiology)
-    pieces.push(`Etiology/Pathophysiology: ${content.etiologyPathophysiology}`);
-  if (content.diagnostics?.notes)
-    pieces.push(`Diagnostics: ${content.diagnostics.notes}`);
-  if (content.clinicalPresentation)
-    pieces.push(`Clinical Presentation: ${content.clinicalPresentation}`);
-  if (content.riskFactors?.length)
-    pieces.push(`Risk Factors: ${content.riskFactors.join("; ")}`);
-  if (content.prognosis) pieces.push(`Prognosis: ${content.prognosis}`);
+
+  const maybeAdd = (key: string, label: string) => {
+    const value = content[key];
+    if (isMeaningfulContent(value)) {
+      pieces.push(`${label}: ${value}`);
+    }
+  };
+
+  maybeAdd("overview", "Overview");
+  maybeAdd("etiology", "Etiology");
+  maybeAdd("diagnostics", "Diagnostics");
+  maybeAdd("clinicalPresentation", "Clinical Presentation");
+  maybeAdd("riskFactors", "Risk Factors");
+  maybeAdd("prognosis", "Prognosis");
 
   return pieces.join("\n");
 }


### PR DESCRIPTION
## Summary
- add centralized loader that reads condition data from the generated JSON at the project root and guards against missing content
- update condition detail rendering to use the new dataset, hide placeholder sections, and render nested bullets with bold formatting
- expose a condition page and shared section renderer while aligning backend context building with the new source

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925aaa987c8832a80aa5082cb97c236)