### PR TITLE
Handle non-string condition content

### DIFF
--- a/components/ConditionDetailModal.tsx
+++ b/components/ConditionDetailModal.tsx
@@ -8,6 +8,7 @@ import {
 import {
   getConditionById,
   isMeaningfulContent,
+  type ConditionContent,
   type ConditionEntry,
 } from "../lib/loadConditions";
 import ConditionSidebar from "./ConditionSidebar";
@@ -22,7 +23,7 @@ interface ConditionDetailModalProps {
 interface ContentSection {
   key: string;
   title: string;
-  content?: string;
+  content?: ConditionContent;
   accent?: "danger" | "default";
 }
 

--- a/components/conditions/FormattedSection.tsx
+++ b/components/conditions/FormattedSection.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { isMeaningfulContent } from "../../lib/loadConditions";
+import {
+  isMeaningfulContent,
+  normalizeConditionContent,
+  type ConditionContent,
+} from "../../lib/loadConditions";
 
 interface BulletNode {
   parts: React.ReactNode[];
@@ -99,22 +103,14 @@ const BulletList: React.FC<{ nodes: BulletNode[]; level: number }> = ({
 };
 
 interface FormattedSectionProps {
-  content?: string | string[] | null;
+  content?: ConditionContent;
 }
 
 const FormattedSection: React.FC<FormattedSectionProps> = ({ content }) => {
-  if (content == null) return null;
+  if (!isMeaningfulContent(content)) return null;
 
-  let text: string;
-
-  if (Array.isArray(content)) {
-    if (content.length === 0) return null;
-    text = content.join("\n");
-  } else {
-    text = typeof content === "string" ? content : String(content);
-  }
-
-  if (!isMeaningfulContent(text)) return null;
+  const text = normalizeConditionContent(content);
+  if (!text) return null;
 
   const bullets = buildBulletTree(text);
 

--- a/lib/loadConditions.ts
+++ b/lib/loadConditions.ts
@@ -1,7 +1,9 @@
 import conditions from "../conditionContent.generated.json";
 
+export type ConditionContent = string | string[] | { notes?: string } | null;
+
 export interface ConditionSections {
-  [sectionKey: string]: string;
+  [sectionKey: string]: ConditionContent;
 }
 
 export interface ConditionEntry {
@@ -36,9 +38,40 @@ export const CONDITIONS = Object.fromEntries(
   ])
 ) as Record<string, ConditionEntry | undefined>;
 
-export function isMeaningfulContent(value?: string | null): boolean {
-  if (!value) return false;
-  const normalized = value.replace(/\s+/g, " ").trim();
+export function normalizeConditionContent(
+  value?: ConditionContent
+): string | null {
+  if (value == null) return null;
+
+  if (typeof value === "string") return value;
+
+  if (Array.isArray(value)) {
+    const parts = value
+      .map((item) =>
+        typeof item === "string"
+          ? item
+          : item != null
+            ? String(item)
+            : ""
+      )
+      .filter(Boolean);
+
+    return parts.length ? parts.join("\n") : null;
+  }
+
+  if (typeof value === "object" && "notes" in value) {
+    const notes = (value as { notes?: unknown }).notes;
+    return typeof notes === "string" ? notes : null;
+  }
+
+  return null;
+}
+
+export function isMeaningfulContent(value?: ConditionContent): boolean {
+  const normalizedValue = normalizeConditionContent(value);
+  if (!normalizedValue) return false;
+
+  const normalized = normalizedValue.replace(/\s+/g, " ").trim();
   if (!normalized) return false;
   return normalized.toUpperCase() !== PLACEHOLDER_TEXT;
 }

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -19,7 +19,11 @@ import {
   findConditionMeta,
   type ConditionMeta,
 } from "../conditionRegistry";
-import { getConditionById, isMeaningfulContent } from "../lib/loadConditions";
+import {
+  getConditionById,
+  isMeaningfulContent,
+  normalizeConditionContent,
+} from "../lib/loadConditions";
 
 // --- Helper: call Netlify serverless function, which talks to Gemini ---
 
@@ -70,7 +74,10 @@ function getConditionRegistryContext(meta: ConditionMeta): string | undefined {
   const maybeAdd = (key: string, label: string) => {
     const value = content[key];
     if (isMeaningfulContent(value)) {
-      pieces.push(`${label}: ${value}`);
+      const normalized = normalizeConditionContent(value);
+      if (normalized) {
+        pieces.push(`${label}: ${normalized}`);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- broaden condition content handling to support lists and note objects without runtime errors
- reuse normalized content when rendering formatted sections and when building Gemini context
- ensure condition detail sections filter and display only meaningful normalized content

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925ca894414832a962e2ea6a908cb31)