### PR TITLE
Pharmacology Search + Drug Modal Support

### DIFF
--- a/components/MenuView.tsx
+++ b/components/MenuView.tsx
@@ -16,7 +16,13 @@ import { ABBREVIATION_TO_TOPIC_MAP } from "../constants";
 import type { SystemDrilldownSelection } from "./SystemDrilldownModal";
 import type { ConditionMeta } from "../conditionRegistry";
 import ConditionDetailModal from "./ConditionDetailModal";
-import { findConditionMetaById, searchConditions } from "../src/lib/conditionSearch";
+import {
+  findConditionMetaById,
+  searchConditions,
+  type SearchResult,
+} from "../src/lib/conditionSearch";
+import DrugModal from "../src/components/modals/DrugModal";
+import { findPharmacologyEntryById } from "../src/services/pharmacologyRegistry";
 
 interface MenuViewProps {
   performanceData: PerformanceRecord[];
@@ -66,6 +72,7 @@ const MenuView: React.FC<MenuViewProps> = ({
   const [selectedCondition, setSelectedCondition] = useState<ConditionMeta | null>(
     null
   );
+  const [selectedDrugId, setSelectedDrugId] = useState<string | null>(null);
 
   const stats = useMemo(() => {
     // Overall score = last 360 questions (any mode) as before
@@ -147,7 +154,21 @@ const MenuView: React.FC<MenuViewProps> = ({
     });
   };
 
-  const searchResults = useMemo(
+  const openConditionModal = (conditionId: string) => {
+    const meta = findConditionMetaById(conditionId);
+    if (meta) {
+      setSelectedCondition(meta);
+    }
+  };
+
+  const openDrugModal = (drugId: string) => {
+    const entry = findPharmacologyEntryById(drugId);
+    if (entry) {
+      setSelectedDrugId(entry.id);
+    }
+  };
+
+  const searchResults: SearchResult[] = useMemo(
     () => {
       const results = searchConditions(searchQuery);
       return results;
@@ -200,6 +221,13 @@ const MenuView: React.FC<MenuViewProps> = ({
         />
       )}
 
+      {selectedDrugId && (
+        <DrugModal
+          drugId={selectedDrugId}
+          onClose={() => setSelectedDrugId(null)}
+        />
+      )}
+
       <div className="flex flex-col max-w-5xl mx-auto px-4">
         <h1 className="text-3xl font-bold text-[#3D1B0E] mb-3 text-center">
           PANaCEa
@@ -212,7 +240,7 @@ const MenuView: React.FC<MenuViewProps> = ({
               type="text"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder="Search conditions (e.g., ACS, Diverticulitis, DKA)..."
+              placeholder="Search conditions or drugs (e.g., ACS, metformin)..."
               className="w-full px-4 py-3 border border-slate-200 rounded-xl text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-[#3D1B0E]/70 focus:border-[#3D1B0E]"
             />
           </div>
@@ -223,9 +251,10 @@ const MenuView: React.FC<MenuViewProps> = ({
                   key={result.id}
                   type="button"
                   onClick={() => {
-                    const meta = findConditionMetaById(result.id);
-                    if (meta) {
-                      setSelectedCondition(meta);
+                    if (result.type === "condition") {
+                      openConditionModal(result.id);
+                    } else {
+                      openDrugModal(result.id);
                     }
                     setSearchQuery("");
                   }}
@@ -233,10 +262,12 @@ const MenuView: React.FC<MenuViewProps> = ({
                 >
                   <div className="flex flex-col gap-0.5">
                     <span className="font-semibold text-slate-800">
-                      {result.condition}
+                      {result.term}
                     </span>
                     <span className="text-[11px] uppercase tracking-wide text-slate-500">
-                      {result.system} • {result.subcategory}
+                      {result.type === "condition"
+                        ? `${result.system} • ${result.subcategory}`
+                        : `${result.class}${result.subclass ? ` • ${result.subclass}` : ""}`}
                     </span>
                   </div>
                 </button>

--- a/src/components/modals/DrugModal.tsx
+++ b/src/components/modals/DrugModal.tsx
@@ -1,0 +1,245 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+
+import ConditionSidebar from "../../../components/ConditionSidebar";
+import FormattedSection from "../../../components/conditions/FormattedSection";
+import { isMeaningfulContent } from "../../../lib/loadConditions";
+import { findPharmacologyEntryById } from "../../services/pharmacologyRegistry";
+import type { PharmacologyEntry } from "../../types/pharmacology";
+
+interface DrugModalProps {
+  drugId: string;
+  onClose: () => void;
+}
+
+interface ContentSection {
+  key:
+    | "overview"
+    | "MOA"
+    | "ADEs"
+    | "contraindications"
+    | "interactions"
+    | "pharmacokinetics"
+    | "antidote"
+    | "clinicalNotes";
+  title: string;
+  content?: string;
+}
+
+const SECTION_ORDER: ContentSection[] = [
+  { key: "overview", title: "Overview" },
+  { key: "MOA", title: "Mechanism of Action (MOA)" },
+  { key: "ADEs", title: "Adverse Drug Effects (ADEs)" },
+  { key: "contraindications", title: "Contraindications" },
+  { key: "interactions", title: "Interactions" },
+  { key: "pharmacokinetics", title: "Pharmacokinetics" },
+  { key: "antidote", title: "Antidote" },
+  { key: "clinicalNotes", title: "Clinical Notes" },
+];
+
+const SCROLL_OFFSET = 96;
+
+const DrugModal: React.FC<DrugModalProps> = ({ drugId, onClose }) => {
+  const [activeSection, setActiveSection] = useState<string>("");
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
+
+  const drug: PharmacologyEntry | undefined = useMemo(
+    () => findPharmacologyEntryById(drugId),
+    [drugId]
+  );
+
+  useEffect(() => {
+    if (!drug) {
+      onClose();
+    }
+  }, [drug, onClose]);
+
+  const sections: ContentSection[] = useMemo(() => {
+    if (!drug) return [];
+
+    return SECTION_ORDER.map((config) => ({
+      ...config,
+      content: drug[config.key],
+    })).filter((section) => isMeaningfulContent(section.content));
+  }, [drug]);
+
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "auto";
+    };
+  }, []);
+
+  useEffect(() => {
+    const container = contentRef.current;
+    if (!container || sections.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const containerRect = container.getBoundingClientRect();
+        let closestKey = "";
+        let smallestDistance = Number.POSITIVE_INFINITY;
+
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return;
+
+          const target = entry.target as HTMLElement;
+          const distance = Math.abs(
+            target.getBoundingClientRect().top - containerRect.top - SCROLL_OFFSET
+          );
+
+          if (distance < smallestDistance) {
+            smallestDistance = distance;
+            closestKey = target.id;
+          }
+        });
+
+        if (closestKey) {
+          setActiveSection(closestKey);
+        }
+      },
+      {
+        root: container,
+        rootMargin: `-${SCROLL_OFFSET}px 0px -60% 0px`,
+        threshold: [0, 0.25, 0.5, 0.75, 1],
+      }
+    );
+
+    const handleScroll = () => {
+      if (container.scrollTop <= 5) {
+        setActiveSection(sections[0].key);
+        return;
+      }
+
+      const bottomGap =
+        container.scrollHeight - (container.scrollTop + container.clientHeight);
+      if (bottomGap <= 2) {
+        setActiveSection(sections[sections.length - 1].key);
+        return;
+      }
+
+      const containerTop = container.getBoundingClientRect().top;
+      let closestKey = sections[0].key;
+      let smallestDistance = Number.POSITIVE_INFINITY;
+
+      sections.forEach((section) => {
+        const el = sectionRefs.current[section.key];
+        if (!el) return;
+
+        const offsetTop = el.getBoundingClientRect().top - containerTop;
+        const distance = Math.abs(offsetTop - SCROLL_OFFSET);
+
+        if (distance < smallestDistance) {
+          smallestDistance = distance;
+          closestKey = section.key;
+        }
+      });
+
+      setActiveSection(closestKey);
+    };
+
+    sections.forEach((section) => {
+      const target = sectionRefs.current[section.key];
+      if (target) {
+        observer.observe(target);
+      }
+    });
+
+    container.addEventListener("scroll", handleScroll, { passive: true });
+    handleScroll();
+
+    return () => {
+      container.removeEventListener("scroll", handleScroll);
+      observer.disconnect();
+    };
+  }, [sections]);
+
+  useEffect(() => {
+    if (sections.length > 0) {
+      setActiveSection(sections[0].key);
+    }
+  }, [sections]);
+
+  const hasAnyContent = sections.length > 0;
+
+  const scrollToSection = (key: string) => {
+    const container = contentRef.current;
+    const target = sectionRefs.current[key];
+
+    if (container && target) {
+      const top = target.offsetTop - container.offsetTop - SCROLL_OFFSET;
+      container.scrollTo({ top: Math.max(top, 0), behavior: "smooth" });
+    }
+  };
+
+  if (!drug) return null;
+
+  return (
+    <div className="condition-modal-overlay">
+      <div className="condition-modal">
+        <header className="condition-modal-header">
+          <div>
+            <h2 className="condition-title">{drug.term}</h2>
+            <p className="condition-meta">
+              {drug.class}
+              {drug.subclass ? ` • ${drug.subclass}` : ""}
+            </p>
+          </div>
+          <button onClick={onClose} className="condition-close">
+            Close
+          </button>
+        </header>
+
+        <div className="condition-layout">
+          <ConditionSidebar
+            sections={sections.map((section) => ({
+              key: section.key,
+              title: section.title,
+            }))}
+            activeSection={activeSection}
+            onSelect={scrollToSection}
+          />
+
+          <div className="condition-content-panel">
+            <div
+              className="condition-scrollable condition-scrollable-padded"
+              ref={contentRef}
+            >
+              <div className="condition-sections">
+                {sections.map((section) => (
+                  <section
+                    key={section.key}
+                    id={section.key}
+                    ref={(el) => {
+                      sectionRefs.current[section.key] = el;
+                    }}
+                    className="condition-card scroll-mt-24"
+                  >
+                    <h3 className="condition-section-title">{section.title}</h3>
+                    <div className="condition-content">
+                      <FormattedSection content={section.content} />
+                    </div>
+                  </section>
+                ))}
+              </div>
+
+              {!hasAnyContent && (
+                <p className="condition-empty">
+                  Detailed notes for this drug haven&apos;t been added yet.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <footer className="condition-footer">
+          <button onClick={onClose} className="condition-close">
+            Close
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+};
+
+export default DrugModal;

--- a/src/data/pharmacology/registry.json
+++ b/src/data/pharmacology/registry.json
@@ -1,0 +1,41 @@
+[
+  {
+    "term": "Aspirin",
+    "class": "NSAID",
+    "subclass": "Salicylate",
+    "overview": "Analgesic and antiplatelet agent used for pain, fever, and cardiovascular prevention.",
+    "MOA": "Irreversibly inhibits COX-1 and COX-2 to decrease prostaglandin and thromboxane synthesis.",
+    "ADEs": "Gastritis or ulceration; bleeding risk; tinnitus at high doses; renal perfusion impairment.",
+    "contraindications": "Active bleeding, aspirin-sensitive asthma, children with viral illness (Reye syndrome risk).",
+    "interactions": "Additive bleeding with anticoagulants/antiplatelets; reduced antihypertensive effect of ACEi/diuretics.",
+    "pharmacokinetics": "Rapid oral absorption; hepatic metabolism with active metabolites; renal elimination of salicylate.",
+    "antidote": "Supportive care; sodium bicarbonate for toxicity; consider hemodialysis in severe overdose.",
+    "clinicalNotes": "Low-dose (81 mg) for secondary prevention; avoid in third-trimester pregnancy; stop before surgery when possible."
+  },
+  {
+    "term": "Warfarin",
+    "class": "Anticoagulant",
+    "subclass": "Vitamin K antagonist",
+    "overview": "Oral anticoagulant for venous thromboembolism prevention and atrial fibrillation stroke prophylaxis.",
+    "MOA": "Inhibits vitamin K epoxide reductase to reduce synthesis of factors II, VII, IX, X and proteins C/S.",
+    "ADEs": "Bleeding; skin necrosis (protein C deficiency); purple toe syndrome; teratogenicity.",
+    "contraindications": "Pregnancy; active bleeding; recent major surgery; uncontrolled hypertension; poor adherence.",
+    "interactions": "CYP2C9/CYP3A4 interactions (amiodarone, azoles, antibiotics) can raise INR; vitamin K intake lowers effect.",
+    "pharmacokinetics": "High oral bioavailability; albumin bound; hepatic metabolism; long half-life with delayed onset/offset.",
+    "antidote": "Vitamin K; 4-factor PCC or FFP for major bleeding; hold doses and monitor INR closely.",
+    "clinicalNotes": "Monitor INR goal 2-3 in most indications; bridge with heparin when starting for acute VTE; educate on diet stability."
+  },
+  {
+    "term": "Metformin",
+    "class": "Antihyperglycemic",
+    "subclass": "Biguanide",
+    "overview": "First-line therapy for type 2 diabetes improving glycemic control without hypoglycemia.",
+    "MOA": "Decreases hepatic gluconeogenesis, increases insulin sensitivity, and enhances peripheral glucose uptake.",
+    "ADEs": "GI upset (nausea, diarrhea); vitamin B12 deficiency; rare lactic acidosis risk in renal/hepatic impairment.",
+    "contraindications": "eGFR <30 mL/min/1.73 m²; unstable heart failure; severe liver disease; history of lactic acidosis.",
+    "interactions": "Cationic drugs (cimetidine) may increase levels; contrast dye may increase lactic acidosis risk.",
+    "pharmacokinetics": "Not metabolized; renal elimination unchanged; half-life ~6 hours; take with meals to improve tolerance.",
+    "antidote": "Supportive care; consider hemodialysis for severe lactic acidosis or overdose.",
+    "clinicalNotes": "Continue unless hospitalized for acute illness; reassess renal function regularly; promotes modest weight loss."
+  }
+]

--- a/src/lib/conditionSearch.test.ts
+++ b/src/lib/conditionSearch.test.ts
@@ -7,7 +7,8 @@ test("fuzzy search matches minor typos", () => {
   const results = searchConditions("fibrilation");
   const top = results[0];
   assert.ok(top, "Expected at least one result");
-  assert.equal(top.condition, "Atrial Fibrillation");
+  assert.equal(top.type, "condition");
+  assert.equal(top.term, "Atrial Fibrillation");
 });
 
 test("returns empty array on blank query", () => {

--- a/src/lib/conditionSearch.ts
+++ b/src/lib/conditionSearch.ts
@@ -4,20 +4,34 @@ import {
   type ConditionMeta,
 } from "../../conditionRegistry.ts";
 import type { SystemCode } from "../../types.ts";
+import type { PharmacologyEntry } from "../types/pharmacology";
+import { PHARMACOLOGY_REGISTRY } from "../services/pharmacologyRegistry";
 
 export interface ConditionSearchFilters {
   system?: SystemCode;
   subcategory?: string;
 }
 
-export interface ConditionSearchResult {
+interface BaseSearchResult {
   id: string;
+  term: string;
+  type: "condition" | "drug";
+  score: number;
+}
+
+export interface ConditionSearchResult extends BaseSearchResult {
+  type: "condition";
   condition: string;
   system: SystemCode;
   subcategory: string;
   aliases: string[];
-  score: number;
 }
+
+export interface DrugSearchResult extends PharmacologyEntry, BaseSearchResult {
+  type: "drug";
+}
+
+export type SearchResult = ConditionSearchResult | DrugSearchResult;
 
 function levenshtein(a: string, b: string): number {
   const dp = Array.from({ length: a.length + 1 }, () =>
@@ -72,7 +86,7 @@ export function getSubcategoryOptions(system?: SystemCode): string[] {
 export function searchConditions(
   rawQuery: string,
   filters: ConditionSearchFilters = {}
-): ConditionSearchResult[] {
+): SearchResult[] {
   const query = rawQuery.trim();
   if (!query) return [];
 
@@ -95,6 +109,8 @@ export function searchConditions(
       const id = buildConditionDefinition(meta).id;
       results.push({
         id,
+        term: meta.condition,
+        type: "condition",
         condition: meta.condition,
         system: meta.system,
         subcategory: meta.subcategory,
@@ -104,8 +120,35 @@ export function searchConditions(
     }
   }
 
-  return results
-    .sort((a, b) => b.score - a.score || a.condition.localeCompare(b.condition))
+  const drugResults: DrugSearchResult[] = [];
+
+  for (const entry of PHARMACOLOGY_REGISTRY) {
+    const searchableFields = [entry.term, entry.class, entry.subclass].filter(
+      Boolean
+    ) as string[];
+
+    let bestScore = 0;
+    for (const term of searchableFields) {
+      const score = bestTermScore(query, term);
+      if (score > bestScore) bestScore = score;
+    }
+
+    if (bestScore > 0.1) {
+      drugResults.push({
+        ...entry,
+        score: bestScore,
+        term: entry.term,
+        type: "drug",
+      });
+    }
+  }
+
+  return [...results, ...drugResults]
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        a.term.localeCompare(b.term)
+    )
     .slice(0, 30);
 }
 

--- a/src/services/pharmacologyRegistry.ts
+++ b/src/services/pharmacologyRegistry.ts
@@ -1,0 +1,27 @@
+import pharmacologyRegistry from "../data/pharmacology/registry.json";
+import type { PharmacologyEntry, PharmacologyRegistry } from "../types/pharmacology";
+
+interface PharmacologyRegistrySourceEntry
+  extends Omit<PharmacologyEntry, "id" | "type"> {}
+
+function slugify(term: string): string {
+  return term
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}
+
+export const PHARMACOLOGY_REGISTRY: PharmacologyRegistry =
+  (pharmacologyRegistry as PharmacologyRegistrySourceEntry[]).map((entry) => ({
+    ...entry,
+    id: slugify(entry.term),
+    type: "drug",
+  }));
+
+export function findPharmacologyEntryById(
+  id: string
+): PharmacologyEntry | undefined {
+  return PHARMACOLOGY_REGISTRY.find((entry) => entry.id === id);
+}

--- a/src/types/pharmacology.ts
+++ b/src/types/pharmacology.ts
@@ -1,0 +1,17 @@
+export interface PharmacologyEntry {
+  id: string;
+  term: string;
+  type: "drug";
+  class: string;
+  subclass?: string;
+  overview?: string;
+  MOA?: string;
+  ADEs?: string;
+  contraindications?: string;
+  interactions?: string;
+  pharmacokinetics?: string;
+  clinicalNotes?: string;
+  antidote?: string;
+}
+
+export type PharmacologyRegistry = PharmacologyEntry[];


### PR DESCRIPTION
## Summary
- add a pharmacology registry source and service that slugifies drug ids for search/index usage
- extend the global search to merge drug entries, route drug clicks to a dedicated DrugModal, and update result metadata
- create a DrugModal that mirrors the condition modal layout with pharmacology-specific sections

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69260c75692c832ab25dacace83e9d98)