### PR TITLE
fix: harden study session bootstrap and simulation launch

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -701,10 +701,12 @@ const App: React.FC = () => {
         } else {
           const token = await getToken();
           let initialQuestions: QuizQuestion[];
+          let sessionEmptyMessage: string | null = null;
           try {
             if (token) {
               const result = await fetchSessionQuestions(settings, token, INITIAL_QUEUE_SIZE);
               initialQuestions = result.questions as QuizQuestion[];
+              sessionEmptyMessage = result.emptyState?.message ?? null;
             } else {
               const { getQuestionBatch } = await import('./services/questionService');
               initialQuestions = await getQuestionBatch(
@@ -714,7 +716,10 @@ const App: React.FC = () => {
                 getToken
               );
             }
-          } catch {
+          } catch (sessionFetchError) {
+            if (settings.simulationStrict) {
+              throw sessionFetchError;
+            }
             const { getQuestionBatch } = await import('./services/questionService');
             initialQuestions = await getQuestionBatch(
               settings,
@@ -725,7 +730,8 @@ const App: React.FC = () => {
           }
           if (initialQuestions.length === 0) {
             setError(
-              'No questions available for your selection. Try adjusting focus or try again later.'
+              sessionEmptyMessage ??
+                'No questions available for your selection. Try adjusting focus or try again later.'
             );
             return;
           }

--- a/docs/debug/production-study-session-fix-summary.md
+++ b/docs/debug/production-study-session-fix-summary.md
@@ -1,0 +1,126 @@
+# Production Study/Simulation Incident Fix Summary
+
+Date: 2026-04-16
+Repo: `/Users/aaronullger/GitHub/StudyPANaCEa`
+Scope: study session launch, signed-in bootstrap endpoints, simulation strict mode, and adjacent noncritical study workspace widgets.
+
+## Root Causes
+
+1. Internal `User.id` and Clerk `auth.userId` were used interchangeably in several user-scoped edge routes.
+2. Signed-in bootstrap depended on a preexisting `User` row, but only some routes attempted to self-heal a missing user record.
+3. Several startup endpoints performed oversized reads or repeated per-system queries, increasing Cloudflare 524 risk during page bootstrap.
+4. Session launch degraded through multiple failing fallback paths and the client collapsed those failures into a misleading "No questions available" state.
+5. Some noncritical authenticated background fetches were fired without a ready token, adding 401 noise and extra startup pressure.
+
+## Fixes Applied
+
+### Shared auth and user bootstrap hardening
+
+- Added shared user resolution helpers in `functions/api/_shared/user-resolver.ts`:
+  - `resolveUserRecord`
+  - `resolveOrCreateUserRecord`
+  - `resolveOrCreateUserId`
+- Standardized the following routes onto shared internal-user resolution and placeholder-user bootstrap:
+  - `functions/api/sync.ts`
+  - `functions/api/user/profile.ts`
+  - `functions/api/user/stats.ts`
+  - `functions/api/srs/due.ts`
+  - `functions/api/analytics/session.ts`
+  - `functions/api/questions/session.ts`
+  - `functions/api/questions/pool.ts`
+- Fixed direct Clerk-ID misuse in:
+  - `functions/api/streaks/auto-freeze.ts`
+  - `functions/api/user/rolling-360-stats.ts`
+
+### Timeout and startup-load reduction
+
+- Reduced oversized seen-history reads in:
+  - `functions/api/questions/pool.ts`
+  - `lib/services/session/sessionService.ts`
+- Reworked `functions/api/questions/pool-status.ts` to avoid repeated per-system count queries and repeated seen-history fetches.
+- Reduced fallback aggregation load in `functions/api/user/stats.ts`.
+- Trimmed the reference index response in `functions/api/reference/scoring-systems/index.ts` to return summary fields only with an explicit cap.
+
+### Session launch resilience
+
+- `functions/api/questions/session.ts`
+  - now returns structured empty-state responses when strict simulation has no eligible questions
+  - logs zero-question outcomes instead of falling through as opaque failures
+- `services/core/mainSessionService.ts`
+  - preserves structured backend error messages
+  - stops strict simulation from automatically cascading into the legacy pool/generation fallback when the primary session service is unavailable
+  - returns a typed degraded response for strict simulation service outages
+- `App.tsx`
+  - now surfaces structured empty/degraded session messages instead of always rendering the generic no-questions string
+
+### Noncritical widget and preload hardening
+
+- Changed noncritical catalog endpoints to public access so study bootstrap is not blocked by auth timing:
+  - `functions/api/content/systems.ts`
+  - `functions/api/reference/scoring-systems/index.ts`
+- Prevented authless preload noise:
+  - `lib/utils/dataLoader.ts` now skips lab-case preload without a usable token
+  - `services/questionService.ts` now skips pool fetch when no token is available
+- Hardened client hooks to fail soft and stop hammering degraded endpoints:
+  - `hooks/useRolling360Stats.ts`
+  - `hooks/useRecentSessions.ts`
+  - `hooks/useSRSItems.ts`
+
+### Route correctness cleanup
+
+- Fixed `functions/api/labs/cases.ts` route schema wiring so the authenticated handler signature is valid.
+
+## Expected Outcome After These Changes
+
+- Study bootstrap no longer depends on every signed-in widget succeeding at once.
+- Strict simulation launch now either:
+  - returns questions successfully, or
+  - returns a structured empty/degraded state with an accurate message.
+- Missing `User` rows no longer cause avoidable bootstrap breakage across profile, stats, sync, SRS, analytics, and session routes.
+- Startup endpoints do less work and should be materially less likely to hit 524 during initial page load.
+- Background 401 noise from tokenless preloads is reduced.
+
+## Remaining Risks
+
+1. `functions/api/sync.ts` and `functions/api/user/stats.ts` are still heavier than ideal and may need deeper query/index optimization if production latency remains high under load.
+2. Placeholder-user creation keeps bootstrap alive, but downstream systems that expect fully populated user metadata may still need follow-up hardening.
+3. If Prisma Accelerate, Neon, or another upstream DB dependency is intermittently unhealthy, some routes may still degrade even with the lighter query shapes.
+4. Verified generation fallback remains a slower secondary path for non-strict flows and should still be monitored for timeout frequency.
+
+## Recommended Follow-Up Instrumentation
+
+1. Add route-level timing logs for:
+   - auth resolution
+   - user bootstrap resolution
+   - DB query duration
+   - total handler duration
+2. Add structured session launch logs for:
+   - requested mode and strict flag
+   - eligible question counts by source
+   - empty-state code
+   - fallback activation
+3. Add explicit error taxonomy tags to API responses and logs:
+   - `unauthorized`
+   - `missing_user_bootstrapped`
+   - `empty_pool`
+   - `generation_timeout`
+   - `upstream_timeout`
+   - `internal_error`
+4. Add alerting on repeated 524s for:
+   - `/api/questions/session`
+   - `/api/questions/pool`
+   - `/api/sync`
+   - `/api/user/stats`
+5. Capture a lightweight study-bootstrap diagnostic event from the client with per-endpoint success/failure and elapsed time so incident triage does not rely on raw browser console output.
+
+## Verification
+
+- Targeted TypeScript transpile checks passed for all edited runtime files.
+- Targeted TypeScript transpile checks passed for updated tests.
+- `npx vitest run functions/api/user/profile.test.ts functions/api/srs/due.test.ts functions/api/sync.test.ts`
+  - Result: 52 tests passed, 0 failed.
+
+## Files Added
+
+- `docs/debug/production-study-session-triage.md`
+- `docs/debug/production-study-session-fix-summary.md`

--- a/docs/debug/production-study-session-triage.md
+++ b/docs/debug/production-study-session-triage.md
@@ -1,0 +1,195 @@
+# Production Study/Simulation Incident Triage
+
+Date: 2026-04-16
+Repo: `/Users/aaronullger/GitHub/StudyPANaCEa`
+Scope: study session bootstrap, simulation launch, signed-in user bootstrap APIs, and adjacent content/reference widgets.
+
+## Summary
+
+This incident is not a single bug. The current production failure pattern is best explained by a combination of:
+
+1. Internal user ID vs Clerk ID mismatches in some edge endpoints.
+2. Missing-user bootstrap paths that do not self-heal consistently.
+3. Several timeout-prone endpoints doing too much work during initial app bootstrap.
+4. A cascading frontend fallback chain that converts backend failures into a misleading "No questions available" state.
+5. A few noncritical background requests firing without auth, which adds 401 noise during already-degraded startup.
+
+The highest-priority repair path is:
+
+1. Fix shared identity resolution for user-scoped endpoints.
+2. Reduce timeout risk in bootstrap/session endpoints.
+3. Make `/api/questions/session` return structured empty/degraded responses instead of opaque failures.
+4. Prevent the client from hammering fallback APIs after the primary session path already failed.
+
+## Endpoint Inventory
+
+| Route | Handler | Auth | Main DB / service deps | Primary risk observed |
+| --- | --- | --- | --- | --- |
+| `/api/questions/session` | `functions/api/questions/session.ts` | `authenticatedEndpoint` | `User`, `SessionService`, `UserQuestionSeen`, `PreGeneratedQuestion`, `Question`, `QuestionSeed`, `MedicalContent` | Launch-critical; user lookup retry path plus multi-source session assembly |
+| `/api/questions/pool` | `functions/api/questions/pool.ts` | `authenticatedEndpoint` | `User`, `UserQuestionSeen`, `PreGeneratedQuestion`, `Question`, `MedicalContent`, Gemini generation | Heavy seen-history + oversized pool fetch + generation fallback |
+| `/api/user/stats` | `functions/api/user/stats.ts` | `authenticatedEndpoint` | `User`, `QuestionAttempt`, `ReviewLog`, `UserQuestionSeen` | Large multi-query aggregation on bootstrap |
+| `/api/user/profile` | `functions/api/user/profile.ts` | `authenticatedEndpoint` | `User` | Simple route, but fails if user row missing or DB unhealthy |
+| `/api/srs/due` | `functions/api/srs/due.ts` | `authenticatedEndpoint` | `User`, `SRSItem` | Should be cheap; currently safe-fails, but still depends on synced user row |
+| `/api/sync` | `functions/api/sync.ts` | `authenticatedEndpoint` | `User`, `PerformanceRecord`, `SRSItem`, `SavedQuestion` | Large reads/writes; missing-user self-heal path is suspect |
+| `/api/streaks/auto-freeze` | `functions/api/streaks/auto-freeze.ts` | `authenticatedEndpoint` | `UserPreferences`, `DailyStreak`, `StreakFreezeUse` | Uses `auth.userId` directly where internal `User.id` is required |
+| `/api/user/rolling-360-stats` | `functions/api/user/rolling-360-stats.ts` | `authenticatedEndpoint` | `Rolling360Service`, `UserRolling360Stats` | Passes Clerk ID into service that expects internal user ID |
+| `/api/content/systems` | `functions/api/content/systems.ts` | `authenticatedEndpoint` | `MedicalContent`, KV cache | Noncritical widget route should fail soft and be cheap |
+| `/api/reference/scoring-systems` | `functions/api/reference/scoring-systems/index.ts` | `authenticatedEndpoint` | `ScoringSystem`, `ScoringSystemConditionLink`, `Condition` | Potentially expensive full-table fetch; not session-critical |
+| `/api/analytics/session` | `functions/api/analytics/session.ts` | `authenticatedEndpoint` | `StudySession`, `SessionAnalytics`, `UserLearningProfile` | GET is used during bootstrap; should not block study workspace |
+| `/api/labs/cases` | `functions/api/labs/cases.ts` | `authenticatedEndpoint` | `LabCase` | Noncritical preload is firing without token and creating 401 noise |
+
+## Frontend Request Chain
+
+### Session launch
+
+1. `pages/SimulationPage.tsx`
+   - User presses CTA.
+   - `simulationStrict = true` is set for "All Topics" simulation.
+2. `App.tsx`
+   - `handleConfirmSession()` calls `services/core/mainSessionService.fetchSessionQuestions()`.
+3. `services/core/mainSessionService.ts`
+   - Primary path: GET `/api/questions/session?...`.
+   - If that fails, it falls back to `fallbackQuestionFetch()`.
+4. `fallbackQuestionFetch()`
+   - Calls legacy `services/questionService.getQuestionBatch()`.
+5. `services/questionService.ts`
+   - Calls `/api/questions/pool`.
+   - If pool is empty or fails, tries verified Gemini generation with per-question timeouts.
+   - If that also fails, throws.
+6. `App.tsx`
+   - Any zero-question result becomes the generic message:
+     `"No questions available for your selection. Try adjusting focus or try again later."`
+
+### Bootstrap/background pressure around the study workspace
+
+- `components/layout/AppLayout.tsx` -> `useStreakAutoFreeze()` -> `/api/streaks/auto-freeze`
+- `hooks/useRolling360Stats.ts` -> `/api/user/rolling-360-stats`
+- `hooks/useSRSItems.ts` -> `/api/srs/due`
+- `hooks/useRecentSessions.ts` -> `/api/analytics/session?limit=100`
+- `hooks/useDatabaseStats.ts` -> `/api/user/stats`
+- `hooks/useUserProfile.ts` / direct `App.tsx` effects -> `/api/user/profile`
+- `lib/utils/dataLoader.ts` preload -> `/api/labs/cases` without guaranteed auth token
+
+This means the simulation page often loads while multiple independent user-scoped endpoints are already competing for the same auth + Prisma + DB resources.
+
+## Root Causes vs Downstream Symptoms
+
+### Root cause 1: Clerk ID / internal User.id mismatch
+
+High confidence.
+
+- `functions/api/streaks/auto-freeze.ts` queries `userPreferences`, `dailyStreak`, and `streakFreezeUse` with `auth.userId`.
+- Those tables are keyed by internal `User.id`, not Clerk ID.
+- Result: avoidable 500s / no-op failures during app bootstrap.
+
+- `functions/api/user/rolling-360-stats.ts` calls:
+  - `rolling360Service.getRolling360Stats(auth.userId, ...)`
+- `lib/services/rolling360Service.ts` expects internal `userId` for `UserRolling360Stats`.
+- Result: wrong-row lookup, empty/misleading response, or wasted DB work.
+
+### Root cause 2: Missing-user bootstrap is brittle
+
+High confidence.
+
+- Many routes assume the `User` row already exists.
+- `functions/api/sync.ts` is the only route trying to self-heal missing users.
+- That self-heal path is a key suspect because it creates a placeholder user row on demand, while other bootstrap routes still return not-found or fail.
+- When webhook sync is delayed or broken, signed-in bootstrap becomes inconsistent across endpoints.
+
+### Root cause 3: Timeout-prone query shapes on startup routes
+
+High confidence.
+
+Important hotspots:
+
+- `functions/api/user/stats.ts`
+  - seven-way parallel aggregate + groupBy + 5,000-record recent attempt load.
+- `functions/api/sync.ts`
+  - large multi-table sync reads/writes with batch merging.
+- `functions/api/questions/pool.ts`
+  - loads up to 10,000 seen IDs, then fetches up to `count * 20` questions when no system filter.
+- `functions/api/questions/pool-status.ts`
+  - N+1-style per-system counts plus repeated user-seen lookups.
+- `lib/services/session/sessionService.ts`
+  - session launch loads seen history, pool count, then fans out across pool + seeds + main table per system.
+
+These routes can individually be slow, and together they increase the chance of 524s during initial page load.
+
+### Root cause 4: Session failure cascades into misleading empty-state UI
+
+High confidence.
+
+- The newer session route fails.
+- The client falls back to the older pool/generation path.
+- The older path also fails or times out.
+- `App.tsx` collapses those distinct failure modes into a single empty-state string.
+
+Result:
+
+- "No questions available" is shown even when the true cause is auth failure, DB failure, or generation timeout.
+
+### Root cause 5: Noncritical authless preload adds noise
+
+Medium confidence.
+
+- `lib/utils/dataLoader.ts` preloads `/api/labs/cases` without a guaranteed token.
+- That endpoint requires auth.
+- This creates background 401 noise during startup and makes incident diagnosis harder.
+
+## Likely Failure Ownership by Symptom
+
+### 401s
+
+- Most likely authless or token-null client fetches.
+- Clear example: `/api/labs/cases` preload.
+- Also possible when hooks send `Authorization: Bearer null` or fetch before Clerk token is ready.
+
+### 500s
+
+- Most likely server exceptions from:
+  - user ID mismatch,
+  - missing user/preferences assumptions,
+  - invalid placeholder-user fallback,
+  - oversized query / Prisma Accelerate failures.
+
+### 524s
+
+- Most likely Cloudflare timing out while waiting on:
+  - heavy DB aggregation,
+  - repeated retries/fallbacks,
+  - multi-source session assembly,
+  - old pool + generation fallback after the primary session route already failed.
+
+## Planned Fixes
+
+1. Add shared internal-user resolution utilities and use them in the failing bootstrap/session routes.
+2. Fix `auto-freeze` to use internal user IDs and fail soft when prefs are missing.
+3. Fix `rolling-360-stats` to resolve internal user IDs before querying stats.
+4. Tighten timeout-prone endpoints:
+   - cap seen-history reads,
+   - reduce oversized fetch multipliers,
+   - short-circuit nonessential work,
+   - avoid session launch blocking on noncritical analytics.
+5. Make `/api/questions/session` return structured empty/degraded responses for:
+   - empty strict simulation eligibility,
+   - service unavailable,
+   - internal error.
+6. Make `mainSessionService` stop cascading into the legacy fallback on every upstream failure.
+7. Improve client bootstrap behavior:
+   - skip requests when token is unavailable,
+   - add failure cooldowns / no-retry behavior for noncritical widgets,
+   - keep partial dashboard/study workspace usable when one widget fails.
+8. Add targeted logging for:
+   - auth resolution,
+   - internal user ID resolution,
+   - session source counts,
+   - empty strict simulation outcomes,
+   - timeout-prone query branches.
+
+## Success Criteria for the Fix Pass
+
+- Study/simulation launch succeeds through `/api/questions/session`, or returns a typed, accurate empty/degraded state.
+- `/api/streaks/auto-freeze`, `/api/user/rolling-360-stats`, `/api/user/profile`, `/api/user/stats`, `/api/srs/due`, and `/api/sync` no longer fail from obvious identity/bootstrap mismatches.
+- Noncritical widget failures stop breaking the workspace.
+- Background authless preload noise is reduced.
+- Logs clearly distinguish auth failure, missing user bootstrap, empty pool, generation timeout, and DB timeout.

--- a/functions/api/_shared/user-resolver.ts
+++ b/functions/api/_shared/user-resolver.ts
@@ -8,6 +8,11 @@
  */
 
 import type { EdgePrismaClient } from './prisma-edge';
+import type { Prisma } from '@prisma/client/edge';
+
+function buildPlaceholderEmail(clerkId: string): string {
+  return `${clerkId}@placeholder.panacea.app`;
+}
 
 /**
  * Resolve internal User id from Clerk id (auth.userId).
@@ -22,4 +27,70 @@ export async function resolveUserId(
     select: { id: true },
   });
   return user?.id ?? null;
+}
+
+/**
+ * Resolve a User row by Clerk id with a caller-provided select projection.
+ */
+export async function resolveUserRecord<TSelect extends Prisma.UserSelect>(
+  prisma: EdgePrismaClient,
+  clerkId: string,
+  select: TSelect
+): Promise<Prisma.UserGetPayload<{ select: TSelect }> | null> {
+  return (await prisma.user.findUnique({
+    where: { clerkId },
+    select,
+  })) as Prisma.UserGetPayload<{ select: TSelect }> | null;
+}
+
+/**
+ * Resolve or create a minimal placeholder User row when Clerk auth succeeds
+ * before the webhook-backed user sync has completed.
+ */
+export async function resolveOrCreateUserRecord<TSelect extends Prisma.UserSelect>(
+  prisma: EdgePrismaClient,
+  clerkId: string,
+  select: TSelect
+): Promise<Prisma.UserGetPayload<{ select: TSelect }>> {
+  const existing = await resolveUserRecord(prisma, clerkId, select);
+  if (existing) {
+    return existing;
+  }
+
+  const now = new Date();
+  const placeholderEmail = buildPlaceholderEmail(clerkId);
+
+  try {
+    await prisma.user.create({
+      data: {
+        id: crypto.randomUUID(),
+        clerkId,
+        email: placeholderEmail,
+        updatedAt: now,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    // Concurrent create or webhook sync may have won the race; re-read below.
+    if (!/unique|constraint|duplicate/i.test(message)) {
+      throw error;
+    }
+  }
+
+  const created = await resolveUserRecord(prisma, clerkId, select);
+  if (!created) {
+    throw new Error(`Failed to resolve or create user for Clerk ID ${clerkId}`);
+  }
+  return created;
+}
+
+/**
+ * Resolve or create the internal User id from Clerk id.
+ */
+export async function resolveOrCreateUserId(
+  prisma: EdgePrismaClient,
+  clerkId: string
+): Promise<string> {
+  const user = await resolveOrCreateUserRecord(prisma, clerkId, { id: true });
+  return user.id;
 }

--- a/functions/api/analytics/session.ts
+++ b/functions/api/analytics/session.ts
@@ -19,6 +19,7 @@ import {
   CACHE_CONFIG,
   isKVAvailable,
 } from '../_shared/cache';
+import { resolveOrCreateUserId } from '../_shared/user-resolver';
 
 type SessionAnalyticsData = z.infer<typeof sessionAnalyticsSchema>;
 type SessionAnalyticsQuery = z.infer<typeof sessionAnalyticsQuerySchema>;
@@ -41,24 +42,13 @@ export const onRequestPost = authenticatedEndpoint(
     try {
       const data = context.validated;
 
-      // Find user by Clerk ID
-      const user = await prisma.user.findUnique({
-        where: { clerkId: context.auth.userId },
-        select: { id: true },
-      });
-
-      if (!user) {
-        return {
-          status: 404,
-          error: 'User not found - must be synced from Clerk webhook first',
-        };
-      }
+      const userId = await resolveOrCreateUserId(prisma, context.auth.userId);
 
       // Create session analytics record
       const session = await prisma.studySession.create({
         data: {
           id: data.sessionId || uuidv4(),
-          userId: user.id,
+          userId,
           startedAt: new Date(data.startedAt),
           endedAt: new Date(data.endedAt),
 
@@ -137,7 +127,7 @@ export const onRequestPost = authenticatedEndpoint(
       await prisma.sessionAnalytics.create({
         data: {
           id: `analytics_${session.id}`,
-          userId: user.id,
+          userId,
           sessionId: session.id,
           totalDurationMinutes: totalDurationMinutes ?? undefined,
           avgResponseTime: data.avgTimePerQuestion ?? undefined,
@@ -147,7 +137,7 @@ export const onRequestPost = authenticatedEndpoint(
       });
 
       // Update user learning profile (upsert)
-      await updateUserLearningProfile(prisma, user.id, data);
+      await updateUserLearningProfile(prisma, userId, data);
 
       return {
         status: 201,
@@ -195,22 +185,11 @@ export const onRequestGet = authenticatedEndpoint(
         }
       }
 
-      // Find user by Clerk ID
-      const user = await prisma.user.findUnique({
-        where: { clerkId: context.auth.userId },
-        select: { id: true },
-      });
-
-      if (!user) {
-        return {
-          status: 404,
-          error: 'User not found',
-        };
-      }
+      const userId = await resolveOrCreateUserId(prisma, context.auth.userId);
 
       // Get recent sessions
       const sessions = await prisma.studySession.findMany({
-        where: { userId: user.id },
+        where: { userId },
         orderBy: { startedAt: 'desc' },
         take: Math.min(limit, 100),
       });
@@ -219,7 +198,7 @@ export const onRequestGet = authenticatedEndpoint(
       let profile = null;
       if (includeProfile) {
         profile = await prisma.userLearningProfile.findUnique({
-          where: { userId: user.id },
+          where: { userId },
         });
       }
 

--- a/functions/api/content/systems.ts
+++ b/functions/api/content/systems.ts
@@ -7,7 +7,7 @@
  */
 
 import { z } from 'zod';
-import { authenticatedEndpoint, withCors } from '../_shared/middleware';
+import { publicEndpoint, withCors } from '../_shared/middleware';
 import { createEdgePrismaClient, safePrismaDisconnect } from '../_shared/prisma-edge';
 import { createEndpointLogger } from '../_shared/secureLogger';
 import { getCached, setCached } from '../_shared/kv-cache';
@@ -19,7 +19,7 @@ const CACHE_TTL = 3600; // 1h
 
 export const onRequestOptions = withCors();
 
-export const onRequestGet = authenticatedEndpoint(ContentSystemsSchema, async (context) => {
+export const onRequestGet = publicEndpoint(ContentSystemsSchema, async (context) => {
   const { env } = context;
   const logger = createEndpointLogger('/api/content/systems');
 

--- a/functions/api/labs/cases.ts
+++ b/functions/api/labs/cases.ts
@@ -3,14 +3,17 @@
  * Edge port of routes/labs.ts
  */
 
+import { z } from 'zod';
 import { withCors, authenticatedEndpoint } from '../_shared/middleware';
 import { createEdgePrismaClient } from '../_shared/prisma-edge';
 import { createEndpointLogger } from '../_shared/secureLogger';
 
+const EmptySchema = z.object({}).optional();
+
 export const onRequestOptions = withCors();
 
 export const onRequestGet = authenticatedEndpoint(
-  undefined,
+  EmptySchema,
   async (context) => {
     const log = createEndpointLogger('labs/cases');
     const prisma = createEdgePrismaClient(context.env.DATABASE_URL);

--- a/functions/api/questions/pool-status.ts
+++ b/functions/api/questions/pool-status.ts
@@ -9,6 +9,7 @@ import { getSystemWeight } from '../../../lib/constants/blueprint';
 import { authenticatedEndpoint, withCors } from '../_shared/middleware';
 import { createEdgePrismaClient, safePrismaDisconnect } from '../_shared/prisma-edge';
 import { createEndpointLogger } from '../_shared/secureLogger';
+import { resolveOrCreateUserRecord } from '../_shared/user-resolver';
 
 const PoolStatusSchema = z.object({
   query: z.object({}),
@@ -46,68 +47,64 @@ export const onRequestGet = authenticatedEndpoint(PoolStatusSchema, async (conte
   const { env, auth } = context;
   const logger = createEndpointLogger('/api/questions/pool-status');
   const prisma = createEdgePrismaClient(env.DATABASE_URL);
+  const MAX_SEEN_LOOKUP = 5_000;
 
   try {
-    // Get user ID for personal stats
-    const user = await prisma.user.findUnique({
-      where: { clerkId: auth.userId },
-      select: { id: true },
-    });
+    const user = await resolveOrCreateUserRecord(prisma, auth.userId, { id: true });
 
-    // Get counts by system (total in pool - multi-tenant: all questions are available)
+    const [groupedCounts, totalInPool, mainQuestionCount, seenQuestions] = await Promise.all([
+      prisma.preGeneratedQuestion.groupBy({
+        by: ['system'],
+        where: { system: { in: SYSTEMS } },
+        _count: { id: true },
+      }),
+      prisma.preGeneratedQuestion.count(),
+      prisma.question.count(),
+      prisma.userQuestionSeen.findMany({
+        where: { userId: user.id },
+        select: { questionId: true },
+        orderBy: { lastSeenAt: 'desc' },
+        take: MAX_SEEN_LOOKUP,
+      }),
+    ]);
+
     const systemCounts: Record<string, { total: number; userSeen: number; userFresh: number }> = {};
     const systemThresholds: Record<string, number> = {};
 
     for (const system of SYSTEMS) {
-      const total = await prisma.preGeneratedQuestion.count({ where: { system } });
-
-      // Get user-specific counts if authenticated
-      let userSeen = 0;
-      if (user) {
-        const seenQuestions = await prisma.userQuestionSeen.findMany({
-          where: { userId: user.id },
-          select: { questionId: true },
-        });
-        type SeenItem = (typeof seenQuestions)[0];
-        const seenIds = seenQuestions.map((h: SeenItem) => h.questionId);
-
-        if (seenIds.length > 0) {
-          userSeen = await prisma.preGeneratedQuestion.count({
-            where: { system, id: { in: seenIds } },
-          });
-        }
-      }
-
+      const group = groupedCounts.find((entry) => entry.system === system);
       systemCounts[system] = {
-        total,
-        userSeen,
-        userFresh: total - userSeen,
+        total: group?._count.id ?? 0,
+        userSeen: 0,
+        userFresh: group?._count.id ?? 0,
       };
       systemThresholds[system] = getSystemThreshold(system);
     }
 
-    // Get overall pool count
-    const totalInPool = await prisma.preGeneratedQuestion.count();
-
-    // Get user's seen count across all systems
+    const seenIds = seenQuestions.map((entry) => entry.questionId);
     let totalUserSeen = 0;
-    if (user) {
-      const allSeenHistory = await prisma.userQuestionSeen.findMany({
-        where: { userId: user.id },
-        select: { questionId: true },
+    if (seenIds.length > 0) {
+      const seenPoolQuestions = await prisma.preGeneratedQuestion.findMany({
+        where: {
+          id: { in: seenIds },
+          system: { in: SYSTEMS },
+        },
+        select: { id: true, system: true },
       });
-      type SeenHistoryItem = (typeof allSeenHistory)[0];
-      const allSeenIds = allSeenHistory.map((h: SeenHistoryItem) => h.questionId);
 
-      if (allSeenIds.length > 0) {
-        totalUserSeen = await prisma.preGeneratedQuestion.count({
-          where: { id: { in: allSeenIds } },
-        });
+      totalUserSeen = seenPoolQuestions.length;
+      for (const seen of seenPoolQuestions) {
+        const system = seen.system ?? 'UNKNOWN';
+        if (!systemCounts[system]) continue;
+        systemCounts[system].userSeen += 1;
+      }
+      for (const system of SYSTEMS) {
+        systemCounts[system].userFresh = Math.max(
+          0,
+          systemCounts[system].total - systemCounts[system].userSeen
+        );
       }
     }
-
-    // Get main Question table count
-    const mainQuestionCount = await prisma.question.count();
 
     // Identify systems that need more questions in the pool (per‑system thresholds)
     const lowSystems = SYSTEMS.filter((s) => (systemCounts[s]?.total ?? 0) < systemThresholds[s]);

--- a/functions/api/questions/pool.ts
+++ b/functions/api/questions/pool.ts
@@ -15,6 +15,7 @@ import {
   CACHE_STRATEGY,
 } from '../_shared/prisma-edge';
 import { createEndpointLogger } from '../_shared/secureLogger';
+import { resolveOrCreateUserRecord } from '../_shared/user-resolver';
 import {
   getFromCache,
   setInCache,
@@ -186,6 +187,7 @@ function mapToPreGeneratedQuestion(r: {
 const POOL_LOW_THRESHOLD = 20;
 const DEFAULT_FETCH_COUNT = 10;
 const BASE_THRESHOLD_MULTIPLIER = 200;
+const MAX_SEEN_HISTORY = 5_000;
 
 function getSystemThreshold(system: string): number {
   const weight = getSystemWeight(system);
@@ -252,17 +254,10 @@ export const onRequestGet = authenticatedEndpoint(
     const prisma = createEdgePrismaClient(env.DATABASE_URL);
 
     try {
-      const user = await prisma.user.findUnique({
-        where: { clerkId: auth.userId },
-        select: { id: true, role: true },
+      const user = await resolveOrCreateUserRecord(prisma, auth.userId, {
+        id: true,
+        role: true,
       });
-
-      if (!user) {
-        return {
-          data: { error: 'User not found', message: 'Your user account has not been synced yet.' },
-          status: 404,
-        };
-      }
 
       const userId = user.id;
       const system = validated.system || null;
@@ -305,7 +300,8 @@ export const onRequestGet = authenticatedEndpoint(
       const seenQuestionIds = await prisma.userQuestionSeen.findMany({
         where: { userId },
         select: { questionId: true },
-        take: 10000, // Bound to prevent memory exhaustion for power users
+        orderBy: { lastSeenAt: 'desc' },
+        take: MAX_SEEN_HISTORY,
       });
       const seenIds = new Set<string>(
         seenQuestionIds.map((q: { questionId: string }) => q.questionId)
@@ -569,9 +565,10 @@ async function getFromPreGeneratedPool(
   let preGenQuestions: PreGeneratedQuestionRecord[];
   let remaining: number;
 
-  // Fetch more questions than needed for PANCE-weighted selection
-  const fetchMultiplier = hasSystemFilter ? 5 : 20; // Fetch 20x when no system filter for better distribution
-  const fetchCount = count * fetchMultiplier;
+  // Bound pool scans to avoid timeouts on large session requests.
+  const fetchCount = hasSystemFilter
+    ? Math.min(Math.max(count * 3, count + 12), 120)
+    : Math.min(Math.max(count * 8, count + 40), 240);
 
   if (cachedQuestions && cachedQuestions.length > 0) {
     preGenQuestions = cachedQuestions;
@@ -729,9 +726,10 @@ async function getFromMainTable(
   const hasSystemFilter = system || (systems && systems.length > 0);
   const logger = createEndpointLogger('pool:getFromMainTable');
 
-  // Fetch more questions than needed for PANCE-weighted selection
-  const fetchMultiplier = hasSystemFilter ? 5 : 20;
-  const fetchCount = count * fetchMultiplier;
+  // Bound main-table scans to avoid large fan-out when the pool is thin.
+  const fetchCount = hasSystemFilter
+    ? Math.min(Math.max(count * 3, count + 10), 100)
+    : Math.min(Math.max(count * 6, count + 30), 180);
 
   const where: Record<string, unknown> = {};
   if (systems?.length) where.system = { in: systems };

--- a/functions/api/questions/session.ts
+++ b/functions/api/questions/session.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 import { authenticatedEndpoint, withCors } from '../_shared/middleware';
 import { createEdgePrismaClient, safePrismaDisconnect } from '../_shared/prisma-edge';
 import { createEndpointLogger } from '../_shared/secureLogger';
+import { resolveOrCreateUserRecord } from '../_shared/user-resolver';
 import {
   SessionService,
   type SessionQuestionRequest,
@@ -48,6 +49,16 @@ export const onRequestGet = authenticatedEndpoint(
   async (context) => {
     const { env, auth, validated } = context;
     const logger = createEndpointLogger('/api/questions/session');
+    const userSelect = {
+      id: true,
+      rotationExamDate: true,
+      currentRotation: true,
+      eorTestDate: true,
+      rotationEndDate: true,
+      examDate: true,
+      yearInProgram: true,
+      trainingPhase: true,
+    } as const;
     logger.info('DATABASE_URL present', { hasUrl: !!env.DATABASE_URL, urlPrefix: env.DATABASE_URL ? env.DATABASE_URL.substring(0, 20) : '' });
     if (!env.DATABASE_URL) {
       logger.error('DATABASE_URL not configured');
@@ -62,51 +73,7 @@ export const onRequestGet = authenticatedEndpoint(
     const prisma = createEdgePrismaClient(env.DATABASE_URL);
     let sessionService: SessionService | null = null;
     try {
-      // Retry user lookup to handle intermittent Accelerate failures
-      let user = null;
-      let userLookupError = null;
-      for (let attempt = 1; attempt <= 3; attempt++) {
-        try {
-          user = await prisma.user.findUnique({
-            where: { clerkId: auth.userId },
-            select: {
-              id: true,
-              rotationExamDate: true,
-              currentRotation: true,
-              eorTestDate: true,
-              rotationEndDate: true,
-              examDate: true,
-              yearInProgram: true,
-              trainingPhase: true,
-            },
-          });
-          break;
-        } catch (error) {
-          userLookupError = error;
-          if (attempt < 3) {
-            await new Promise(resolve => setTimeout(resolve, 1000 * attempt));
-          }
-        }
-      }
-
-      if (!user) {
-        // If user lookup fails, log but continue with a placeholder user ID
-        // The session service will handle missing user gracefully
-        logger.warn('User lookup failed after retries, using placeholder', {
-          error: userLookupError?.message,
-          userId: auth.userId,
-        });
-        // Use a placeholder ID that won't conflict with real users
-        const placeholderUserId = -1;
-        // For now, return 503 to avoid corrupting user data
-        return {
-          data: {
-            error: 'Session service unavailable',
-            message: 'Database is temporarily unavailable. Please try again.',
-          },
-          status: 503,
-        };
-      }
+      const user = await resolveOrCreateUserRecord(prisma, auth.userId, userSelect);
 
       const count = Math.min(parseInt(validated?.count || '10', 10), 50);
       const system = validated?.system || undefined;
@@ -143,9 +110,31 @@ export const onRequestGet = authenticatedEndpoint(
       logger.info('Session questions fetched (GET)', {
         userId: auth.userId,
         count: result.questions?.length || 0,
+        requestedCount: count,
+        simulationStrict,
       });
 
-      return { data: result };
+      const emptyState =
+        result.questions.length === 0
+          ? {
+              code: simulationStrict ? 'SIMULATION_EMPTY' : 'SESSION_EMPTY',
+              message: simulationStrict
+                ? 'No eligible questions are currently available for a strict simulation. Please try again shortly.'
+                : 'No questions matched this session configuration. Try a broader focus or try again later.',
+            }
+          : undefined;
+
+      if (emptyState) {
+        logger.warn('Session request returned no questions', {
+          userId: auth.userId,
+          code: emptyState.code,
+          requestedCount: count,
+          simulationStrict,
+          sessionLane,
+        });
+      }
+
+      return { data: emptyState ? { ...result, emptyState } : result };
     } catch (error) {
       const errMsg = error instanceof Error ? error.message : String(error);
       const stack = error instanceof Error ? error.stack : undefined;
@@ -187,6 +176,16 @@ export const onRequestGet = authenticatedEndpoint(
 export const onRequestPost = authenticatedEndpoint(SessionPostSchema, async (context) => {
   const { env, auth, validated } = context;
   const logger = createEndpointLogger('/api/questions/session');
+  const userSelect = {
+    id: true,
+    rotationExamDate: true,
+    currentRotation: true,
+    eorTestDate: true,
+    rotationEndDate: true,
+    examDate: true,
+    yearInProgram: true,
+    trainingPhase: true,
+  } as const;
   logger.info('DATABASE_URL present', { hasUrl: !!env.DATABASE_URL, urlPrefix: env.DATABASE_URL ? env.DATABASE_URL.substring(0, 20) : '' });
   if (!env.DATABASE_URL) {
     logger.error('DATABASE_URL not configured');
@@ -199,51 +198,7 @@ export const onRequestPost = authenticatedEndpoint(SessionPostSchema, async (con
   let sessionService: SessionService | null = null;
 
   try {
-    // Retry user lookup to handle intermittent Accelerate failures
-    let user = null;
-    let userLookupError = null;
-      for (let attempt = 1; attempt <= 3; attempt++) {
-        try {
-          user = await prisma.user.findUnique({
-            where: { clerkId: auth.userId },
-            select: {
-              id: true,
-              rotationExamDate: true,
-              currentRotation: true,
-              eorTestDate: true,
-              rotationEndDate: true,
-              examDate: true,
-              yearInProgram: true,
-              trainingPhase: true,
-            },
-          });
-          break;
-      } catch (error) {
-        userLookupError = error;
-        if (attempt < 3) {
-          await new Promise(resolve => setTimeout(resolve, 1000 * attempt));
-        }
-      }
-    }
-
-    if (!user) {
-      // If user lookup fails, log but continue with a placeholder user ID
-      // The session service will handle missing user gracefully
-      logger.warn('User lookup failed after retries, using placeholder', {
-        error: userLookupError?.message,
-        userId: auth.userId,
-      });
-      // Use a placeholder ID that won't conflict with real users
-      const placeholderUserId = -1;
-      // For now, return 503 to avoid corrupting user data
-      return {
-        data: {
-          error: 'Session service unavailable',
-          message: 'Database is temporarily unavailable. Please try again.',
-        },
-        status: 503,
-      };
-    }
+    const user = await resolveOrCreateUserRecord(prisma, auth.userId, userSelect);
 
     sessionService = new SessionService(env.DATABASE_URL, env);
     const learnerPhasePost = inferLearnerPhase(user);
@@ -273,9 +228,31 @@ export const onRequestPost = authenticatedEndpoint(SessionPostSchema, async (con
     logger.info('Session questions fetched (POST)', {
       userId: auth.userId,
       count: result.questions?.length || 0,
+      requestedCount: Math.min(validated.count || 10, 50),
+      simulationStrict: postSimStrict,
     });
 
-    return { data: result };
+    const emptyState =
+      result.questions.length === 0
+        ? {
+            code: postSimStrict ? 'SIMULATION_EMPTY' : 'SESSION_EMPTY',
+            message: postSimStrict
+              ? 'No eligible questions are currently available for a strict simulation. Please try again shortly.'
+              : 'No questions matched this session configuration. Try a broader focus or try again later.',
+          }
+        : undefined;
+
+    if (emptyState) {
+      logger.warn('Session request returned no questions', {
+        userId: auth.userId,
+        code: emptyState.code,
+        requestedCount: Math.min(validated.count || 10, 50),
+        simulationStrict: postSimStrict,
+        sessionLane: postSessionLane,
+      });
+    }
+
+    return { data: emptyState ? { ...result, emptyState } : result };
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
     const stack = error instanceof Error ? error.stack : undefined;

--- a/functions/api/reference/scoring-systems/index.ts
+++ b/functions/api/reference/scoring-systems/index.ts
@@ -13,7 +13,7 @@
  */
 
 import { z } from 'zod';
-import { authenticatedEndpoint, withCors } from '../../_shared/middleware';
+import { publicEndpoint, withCors } from '../../_shared/middleware';
 import {
   createEdgePrismaClient,
   safePrismaDisconnect,
@@ -43,10 +43,10 @@ const ScoringSystemsQuerySchema = z.object({
 
 export const onRequestOptions = withCors();
 
-export const onRequestGet = authenticatedEndpoint(
+export const onRequestGet = publicEndpoint(
   ScoringSystemsQuerySchema,
-  async ({ env, auth, request }) => {
-    const log = createEndpointLogger('/api/reference/scoring-systems', auth.userId);
+  async ({ env, request }) => {
+    const log = createEndpointLogger('/api/reference/scoring-systems');
     let prisma: EdgePrismaClient | null = null;
 
     try {
@@ -89,20 +89,18 @@ export const onRequestGet = authenticatedEndpoint(
           { panceYield: 'desc' },
           { name: 'asc' },
         ],
-        include: {
-          ScoringSystemConditionLink: {
-            select: {
-              conditionId: true,
-              Condition: {
-                select: {
-                  id: true,
-                  canonicalName: true,
-                  system: true,
-                },
-              },
-            },
-            take: 10,
-          },
+        take: 250,
+        select: {
+          id: true,
+          name: true,
+          displayName: true,
+          category: true,
+          condition: true,
+          panceYield: true,
+          isHighYield: true,
+          maxScore: true,
+          sensitivity: true,
+          specificity: true,
         },
       });
 

--- a/functions/api/srs/due.test.ts
+++ b/functions/api/srs/due.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const { mockPrisma, mockSafePrismaDisconnect, captured } = vi.hoisted(() => ({
   mockPrisma: {
-    user: { findUnique: vi.fn() },
+    user: { findUnique: vi.fn(), create: vi.fn() },
     sRSItem: { findMany: vi.fn() },
   },
   mockSafePrismaDisconnect: vi.fn(),
@@ -80,15 +80,18 @@ describe('GET /api/srs/due', () => {
     vi.useRealTimers();
   });
 
-  it('returns 404 when user not found', async () => {
-    mockPrisma.user.findUnique.mockResolvedValue(null);
+  it('creates a placeholder user when the row is missing', async () => {
+    mockPrisma.user.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 'user-1' });
+    mockPrisma.user.create.mockResolvedValue({ id: 'user-1' });
+    mockPrisma.sRSItem.findMany.mockResolvedValue([]);
 
     const result = await captured.handler(makeContext());
 
-    expect(result).toEqual({
-      data: { error: 'User not found. Please refresh and try again.' },
-      status: 404,
-    });
+    expect(mockPrisma.user.create).toHaveBeenCalledTimes(1);
+    expect(result.data.items).toEqual([]);
+    expect(result.data.totalDue).toBe(0);
   });
 
   it('returns due items with overdueDays calculated correctly', async () => {

--- a/functions/api/srs/due.ts
+++ b/functions/api/srs/due.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import { authenticatedEndpoint, withCors } from '../_shared/middleware';
 import { createEdgePrismaClient, safePrismaDisconnect } from '../_shared/prisma-edge';
 import { createEndpointLogger } from '../_shared/secureLogger';
+import { resolveOrCreateUserId } from '../_shared/user-resolver';
 
 const SRSDueSchema = z.object({
   query: z
@@ -30,22 +31,7 @@ export const onRequestGet = authenticatedEndpoint(SRSDueSchema, async (context) 
 
   try {
     prisma = createEdgePrismaClient(env.DATABASE_URL);
-
-    // Look up user by clerkId
-    const user = await prisma.user.findUnique({
-      where: { clerkId: auth.userId },
-      select: { id: true },
-    });
-
-    if (!user) {
-      logger.warn('User not found in database', { clerkId: auth.userId.substring(0, 10) });
-      return {
-        data: { error: 'User not found. Please refresh and try again.' },
-        status: 404,
-      };
-    }
-
-    const userId = user.id;
+    const userId = await resolveOrCreateUserId(prisma, auth.userId);
     const now = new Date();
     const limit = validated.query?.limit || 100;
 

--- a/functions/api/streaks/auto-freeze.ts
+++ b/functions/api/streaks/auto-freeze.ts
@@ -12,6 +12,7 @@
 import { authenticatedEndpoint, withCors } from '../_shared/middleware';
 import { createEdgePrismaClient, safePrismaDisconnect } from '../_shared/prisma-edge';
 import { createEndpointLogger } from '../_shared/secureLogger';
+import { resolveOrCreateUserId } from '../_shared/user-resolver';
 import { isGoalDay, previousGoalDay, lastGoalDayOnOrBefore, type StreakGoalDays } from '../../../lib/streakCalc';
 
 export const onRequestOptions = withCors();
@@ -39,10 +40,11 @@ export const onRequestPost = authenticatedEndpoint({}, async (context) => {
   try {
     prisma = createEdgePrismaClient(env.DATABASE_URL);
     const today = toMidnightUTC(new Date());
+    const internalUserId = await resolveOrCreateUserId(prisma, auth.userId);
 
     // Fetch user preferences
     const prefs = await prisma.userPreferences.findUnique({
-      where: { userId: auth.userId },
+      where: { userId: internalUserId },
       select: { streakFreezes: true, streakGoalDays: true },
     });
 
@@ -63,14 +65,14 @@ export const onRequestPost = authenticatedEndpoint({}, async (context) => {
     const [activities, existingFreezes] = await Promise.all([
       prisma.dailyStreak.findMany({
         where: {
-          userId: auth.userId,
+          userId: internalUserId,
           date: { gte: twoWeeksAgo },
         },
         select: { date: true },
       }),
       prisma.streakFreezeUse.findMany({
         where: {
-          userId: auth.userId,
+          userId: internalUserId,
           date: { gte: twoWeeksAgo },
         },
         select: { date: true },
@@ -133,16 +135,16 @@ export const onRequestPost = authenticatedEndpoint({}, async (context) => {
     const operations = freezesToApply.map((date) =>
       prisma!.streakFreezeUse.upsert({
         where: {
-          userId_date: { userId: auth.userId, date },
+          userId_date: { userId: internalUserId, date },
         },
-        create: { userId: auth.userId, date },
+        create: { userId: internalUserId, date },
         update: {},
       })
     );
 
     operations.push(
       prisma.userPreferences.update({
-        where: { userId: auth.userId },
+        where: { userId: internalUserId },
         data: { streakFreezes: { decrement: freezesToApply.length } },
       }) as any
     );
@@ -150,7 +152,7 @@ export const onRequestPost = authenticatedEndpoint({}, async (context) => {
     await prisma.$transaction(operations);
 
     logger.info('Auto-freeze applied', {
-      userId: auth.userId,
+      userId: internalUserId,
       freezesApplied: freezesToApply.length,
       dates: freezesToApply.map(toDateKey),
     });

--- a/functions/api/sync.ts
+++ b/functions/api/sync.ts
@@ -22,6 +22,7 @@ import {
 import { authenticatedEndpoint, withCors } from './_shared/middleware';
 import { createEndpointLogger } from './_shared/secureLogger';
 import { getFromCache, setInCache, isKVAvailable } from './_shared/cache';
+import { resolveOrCreateUserId } from './_shared/user-resolver';
 
 // ============================================================================
 // SCHEMAS
@@ -170,33 +171,6 @@ function chunk<T>(array: T[], size: number): T[][] {
     chunks.push(array.slice(i, i + size));
   }
   return chunks;
-}
-
-/**
- * Resolve Clerk ID to Internal DB ID
- */
-async function resolveUserId(prisma: EdgePrismaClient, clerkId: string): Promise<string> {
-  const existingUser = await prisma.user.findUnique({
-    where: { clerkId },
-    select: { id: true },
-  });
-
-  if (existingUser) {
-    return existingUser.id;
-  }
-
-  // User doesn't exist, create them
-  const now = new Date();
-  const newUser = await prisma.user.create({
-    data: {
-      clerkId,
-      email: `${clerkId}@placeholder.panacea.app`,
-      updatedAt: now,
-    },
-    select: { id: true },
-  });
-
-  return newUser.id;
 }
 
 /**
@@ -387,13 +361,7 @@ export const onRequestGet = authenticatedEndpoint(
       prisma = createEdgePrismaClient(context.env.DATABASE_URL);
 
       // Resolve clerkId to internal userId
-      const internalUserId = await resolveUserId(prisma, context.auth.userId);
-      if (!internalUserId) {
-        return {
-          data: { success: false, error: 'User not found. Please sign out and back in.' },
-          status: 404,
-        };
-      }
+      const internalUserId = await resolveOrCreateUserId(prisma, context.auth.userId);
 
       // Fetch all user data in parallel (bounded + column-limited for performance)
       const [performanceRecords, srsItems, savedQuestions] = await Promise.all([
@@ -485,7 +453,7 @@ export const onRequestPost = authenticatedEndpoint(PostSyncSchema, async (contex
 
     // Resolve user ID with retry for transient failures
     const internalUserId = await withRetry(
-      () => resolveUserId(prisma!, context.auth.userId),
+      () => resolveOrCreateUserId(prisma!, context.auth.userId),
       'resolveUserId',
       log
     );

--- a/functions/api/user/profile.test.ts
+++ b/functions/api/user/profile.test.ts
@@ -14,11 +14,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const {
   mockFindUnique,
+  mockCreate,
   mockUpdate,
   mockDisconnect,
   capturedHandlers,
 } = vi.hoisted(() => {
   const mockFindUnique = vi.fn();
+  const mockCreate = vi.fn();
   const mockUpdate = vi.fn();
   const mockDisconnect = vi.fn().mockResolvedValue(undefined);
   const capturedHandlers: { get: ((ctx: any) => Promise<any>) | null; put: ((ctx: any) => Promise<any>) | null; index: number } = {
@@ -26,12 +28,12 @@ const {
     put: null,
     index: 0,
   };
-  return { mockFindUnique, mockUpdate, mockDisconnect, capturedHandlers };
+  return { mockFindUnique, mockCreate, mockUpdate, mockDisconnect, capturedHandlers };
 });
 
 vi.mock('../_shared/prisma-edge', () => ({
   createEdgePrismaClient: () => ({
-    user: { findUnique: mockFindUnique, update: mockUpdate },
+    user: { findUnique: mockFindUnique, create: mockCreate, update: mockUpdate },
   }),
   safePrismaDisconnect: (...args: unknown[]) => mockDisconnect(...args),
 }));
@@ -214,13 +216,32 @@ describe('GET /api/user/profile', () => {
     vi.clearAllMocks();
   });
 
-  it('returns 404 when user not found', async () => {
-    mockFindUnique.mockResolvedValue(null);
+  it('creates a placeholder user when the row is missing', async () => {
+    const placeholderUser = makeMockUser({
+      email: 'clerk_user_123@placeholder.panacea.app',
+      firstName: null,
+      lastName: null,
+      examDate: null,
+      graduationDate: null,
+      school: null,
+      currentRotation: null,
+      yearInProgram: null,
+      rotationExamDate: null,
+      eorTestDate: null,
+      rotationStartDate: null,
+      rotationEndDate: null,
+      hasCompletedBaseline: false,
+      hasCompletedOnboarding: false,
+    });
+    mockFindUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(placeholderUser);
+    mockCreate.mockResolvedValue({ id: 'uuid-1' });
     const result = await capturedHandlers.get!(makeContext());
 
-    expect(result.status).toBe(404);
-    expect(result.data.success).toBe(false);
-    expect(result.data.error).toContain('User not found');
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(result.data.success).toBe(true);
+    expect(result.data.profile.email).toBe('clerk_user_123@placeholder.panacea.app');
   });
 
   it('returns profile with ISO date strings when user found', async () => {
@@ -313,13 +334,17 @@ describe('PUT /api/user/profile', () => {
     vi.clearAllMocks();
   });
 
-  it('returns 404 when user not found', async () => {
-    mockFindUnique.mockResolvedValue(null);
+  it('creates a placeholder user before updating when the row is missing', async () => {
+    mockFindUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 'uuid-1' });
+    mockCreate.mockResolvedValue({ id: 'uuid-1' });
+    mockUpdate.mockResolvedValue(makeMockUser({ firstName: 'X' }));
     const result = await capturedHandlers.put!(makeContext({ validated: { firstName: 'X' } }));
 
-    expect(result.status).toBe(404);
-    expect(result.data.success).toBe(false);
-    expect(result.data.error).toContain('User not found');
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(result.data.success).toBe(true);
+    expect(result.data.profile.firstName).toBe('X');
   });
 
   it('updates user and returns profile with ISO dates', async () => {
@@ -347,7 +372,7 @@ describe('PUT /api/user/profile', () => {
 
     expect(mockUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { clerkId: 'clerk_user_123' },
+        where: { id: 'uuid-1' },
         data: { firstName: 'Updated', school: 'Harvard' },
       })
     );

--- a/functions/api/user/profile.ts
+++ b/functions/api/user/profile.ts
@@ -13,6 +13,7 @@ import { authenticatedEndpoint, withCors } from '../_shared/middleware';
 import { profileUpdateSchema } from '../_shared/zodSchemas';
 import { createEdgePrismaClient, safePrismaDisconnect } from '../_shared/prisma-edge';
 import { createEndpointLogger } from '../_shared/secureLogger';
+import { resolveOrCreateUserRecord } from '../_shared/user-resolver';
 
 const EmptySchema = z.object({});
 
@@ -57,40 +58,30 @@ export const onRequestGet = authenticatedEndpoint(
     const { env, auth } = context;
     const logger = createEndpointLogger('/api/user/profile');
     const prisma = createEdgePrismaClient(env.DATABASE_URL);
+    const profileSelect = {
+      id: true,
+      clerkId: true,
+      email: true,
+      firstName: true,
+      lastName: true,
+      examDate: true,
+      graduationDate: true,
+      school: true,
+      currentRotation: true,
+      yearInProgram: true,
+      rotationExamDate: true,
+      eorTestDate: true,
+      rotationStartDate: true,
+      rotationEndDate: true,
+      hasCompletedBaseline: true,
+      hasCompletedOnboarding: true,
+      updatedAt: true,
+    } as const;
 
     try {
       logger.addContext({ userId: auth.userId });
 
-      const user = await prisma.user.findUnique({
-        where: { clerkId: auth.userId },
-        select: {
-          id: true,
-          clerkId: true,
-          email: true,
-          firstName: true,
-          lastName: true,
-          examDate: true,
-          graduationDate: true,
-          school: true,
-          currentRotation: true,
-          yearInProgram: true,
-          rotationExamDate: true,
-          eorTestDate: true,
-          rotationStartDate: true,
-          rotationEndDate: true,
-          hasCompletedBaseline: true,
-          hasCompletedOnboarding: true,
-          updatedAt: true,
-        },
-      });
-
-      if (!user) {
-        logger.warn('User not found', { clerkId: auth.userId });
-        return {
-          data: { success: false, error: 'User not found. Please log in again.' },
-          status: 404,
-        };
-      }
+      const user = await resolveOrCreateUserRecord(prisma, auth.userId, profileSelect);
 
       return {
         data: {
@@ -129,49 +120,38 @@ export const onRequestPut = authenticatedEndpoint(profileUpdateSchema, async (co
   const { env, auth, validated } = context;
   const logger = createEndpointLogger('/api/user/profile');
   const prisma = createEdgePrismaClient(env.DATABASE_URL);
+  const profileSelect = {
+    id: true,
+    clerkId: true,
+    email: true,
+    firstName: true,
+    lastName: true,
+    examDate: true,
+    graduationDate: true,
+    school: true,
+    currentRotation: true,
+    yearInProgram: true,
+    rotationExamDate: true,
+    eorTestDate: true,
+    rotationStartDate: true,
+    rotationEndDate: true,
+    hasCompletedBaseline: true,
+    hasCompletedOnboarding: true,
+    updatedAt: true,
+  } as const;
 
   try {
     logger.addContext({ userId: auth.userId });
 
-    // Resolve user by clerkId (auth.userId is Clerk sub)
-    const user = await prisma.user.findUnique({
-      where: { clerkId: auth.userId },
-      select: { id: true },
-    });
-
-    if (!user) {
-      logger.warn('User not found', { clerkId: auth.userId });
-      return {
-        data: { success: false, error: 'User not found. Please log in again.' },
-        status: 404,
-      };
-    }
+    const user = await resolveOrCreateUserRecord(prisma, auth.userId, { id: true });
 
     // Build update payload (exclude undefined, handle dates)
     const updateData = buildProfileUpdateData(validated);
 
     const updatedUser = await prisma.user.update({
-      where: { clerkId: auth.userId },
+      where: { id: user.id },
       data: updateData,
-      select: {
-        id: true,
-        clerkId: true,
-        email: true,
-        firstName: true,
-        lastName: true,
-        examDate: true,
-        graduationDate: true,
-        school: true,
-        currentRotation: true,
-        yearInProgram: true,
-        rotationExamDate: true,
-        eorTestDate: true,
-        rotationStartDate: true,
-        rotationEndDate: true,
-        hasCompletedBaseline: true,
-        hasCompletedOnboarding: true,
-        updatedAt: true,
-      },
+      select: profileSelect,
     });
 
     logger.info('Profile updated', { userId: user.id, fields: Object.keys(updateData) });

--- a/functions/api/user/rolling-360-stats.ts
+++ b/functions/api/user/rolling-360-stats.ts
@@ -10,6 +10,7 @@ import { authenticatedEndpoint, withCors, getSentryTraceId } from '../_shared/mi
 import { createEdgePrismaClient, safePrismaDisconnect } from '../_shared/prisma-edge';
 import { createEndpointLogger } from '../_shared/secureLogger';
 import { withTimeout, TimeoutError } from '../_shared/timeout';
+import { resolveOrCreateUserId } from '../_shared/user-resolver';
 import { Rolling360Service } from '../../../lib/services/rolling360Service';
 
 const ROLLING_360_TIMEOUT_MS = 8_000; // 8s so we respond before Worker "code had hung" kill
@@ -47,16 +48,17 @@ export const onRequestGet = authenticatedEndpoint(Rolling360StatsSchema, async (
 
   try {
     prisma = createEdgePrismaClient(env.DATABASE_URL);
+    const internalUserId = await resolveOrCreateUserId(prisma, auth.userId);
     const rolling360Service = new Rolling360Service(prisma);
     const stats = await withTimeout(
-      rolling360Service.getRolling360Stats(auth.userId, { skipCalibration: true }),
+      rolling360Service.getRolling360Stats(internalUserId, { skipCalibration: true }),
       ROLLING_360_TIMEOUT_MS,
       'Rolling 360 stats request timed out'
     );
 
     // Safety: Return structured empty state if no data exists
     if (!stats) {
-      logger.info('Returning empty state for new user', { userId: auth.userId });
+      logger.info('Returning empty state for new user', { userId: internalUserId });
       return { data: EMPTY_STATE_RESPONSE };
     }
 
@@ -69,7 +71,7 @@ export const onRequestGet = authenticatedEndpoint(Rolling360StatsSchema, async (
     }
 
     logger.info('Fetched Rolling 360 stats', {
-      userId: auth.userId,
+      userId: internalUserId,
       totalInWindow: stats.totalInWindow,
       scoreConfidence: stats.scoreConfidence,
     });

--- a/functions/api/user/stats.ts
+++ b/functions/api/user/stats.ts
@@ -11,7 +11,7 @@
 import { z } from 'zod';
 import { authenticatedEndpoint, withCors } from '../_shared/middleware';
 import { createEdgePrismaClient, safePrismaDisconnect } from '../_shared/prisma-edge';
-import { resolveUserId } from '../_shared/user-resolver';
+import { resolveOrCreateUserId } from '../_shared/user-resolver';
 import { createEndpointLogger } from '../_shared/secureLogger';
 import {
   getFromCache,
@@ -25,6 +25,7 @@ import { normalizeSystemName, getAllSystems } from '@/lib/constants/blueprint';
 const UserStatsSchema = z.object({
   query: z.object({}).optional(), // No query params for this endpoint
 });
+const RECENT_ATTEMPT_LIMIT = 2_000;
 
 export const onRequestOptions = withCors();
 
@@ -71,14 +72,8 @@ export const onRequestGet = authenticatedEndpoint(UserStatsSchema, async (contex
       };
     }
 
-    const userId = await resolveUserId(prisma, auth.userId);
+    const userId = await resolveOrCreateUserId(prisma, auth.userId);
     logger.info('user/stats step', { step: 'resolveUserId', hasUserId: !!userId });
-    if (!userId) {
-      return {
-        data: { success: false, error: 'User not found - must be synced from Clerk webhook first' },
-        status: 404,
-      };
-    }
 
     // Check cache first if KV is available
     if (isKVAvailable(env.CACHE)) {
@@ -149,7 +144,7 @@ export const onRequestGet = authenticatedEndpoint(UserStatsSchema, async (contex
             createdAt: true,
           },
           orderBy: { createdAt: 'desc' },
-          take: 5000,
+          take: RECENT_ATTEMPT_LIMIT,
         }),
         prisma.userQuestionSeen.count({ where: { userId } }),
       ]);
@@ -187,7 +182,7 @@ export const onRequestGet = authenticatedEndpoint(UserStatsSchema, async (contex
               reviewedAt: true,
             },
             orderBy: { reviewedAt: 'desc' },
-            take: 5000,
+            take: RECENT_ATTEMPT_LIMIT,
           }),
           prisma.userQuestionSeen.count({ where: { userId } }),
         ]);

--- a/hooks/useRecentSessions.ts
+++ b/hooks/useRecentSessions.ts
@@ -27,11 +27,11 @@ interface SessionAnalyticsResponse {
 function createSessionFetcher(getToken: () => Promise<string | null>) {
   return async (url: string): Promise<RawSessionRecord[]> => {
     const token = await getToken();
-    if (!token) throw new Error('Not authenticated');
+    if (!token) return [];
     const res = await fetch(url, {
       headers: { Authorization: `Bearer ${token}` },
     });
-    if (!res.ok) throw new Error('Failed to fetch sessions');
+    if (!res.ok) return [];
     const data = (await res.json()) as SessionAnalyticsResponse | { data?: SessionAnalyticsResponse };
     // Handle both { sessions: [...] } and { data: { sessions: [...] } } shapes
     const sessions = ('data' in data && data.data?.sessions) || ('sessions' in data && data.sessions) || [];
@@ -57,6 +57,8 @@ export function useRecentSessions(): {
     {
       revalidateOnFocus: false,
       dedupingInterval: 60_000, // 1 minute
+      shouldRetryOnError: false,
+      fallbackData: [],
     }
   );
 

--- a/hooks/useRolling360Stats.ts
+++ b/hooks/useRolling360Stats.ts
@@ -107,6 +107,10 @@ const EMPTY_STATS: Rolling360Stats = {
 // =============================================================================
 
 async function fetchRolling360Stats(url: string, token: string | null): Promise<Rolling360Stats> {
+  if (!token) {
+    return EMPTY_STATS;
+  }
+
   const response = await fetch(url, {
     headers: {
       Authorization: `Bearer ${token}`,

--- a/hooks/useSRSItems.ts
+++ b/hooks/useSRSItems.ts
@@ -78,12 +78,16 @@ export function useSRSItems(): UseSRSItemsResult {
     queryKey: ['srs', 'due', isSignedIn ? user?.id : null],
     queryFn: async () => {
       const token = await getToken();
+      if (!token) {
+        return { items: [], totalDue: 0 };
+      }
       return fetchDueFromApi(token);
     },
     enabled: !!isSignedIn && !!user,
     staleTime: 1000 * 60 * 2, // 2 minutes
     gcTime: 1000 * 60 * 60 * 24,
     refetchOnWindowFocus: true,
+    retry: false,
   });
 
   // When coming back online, refetch due items so cache is updated after offline queue flush

--- a/lib/services/session/sessionService.ts
+++ b/lib/services/session/sessionService.ts
@@ -4,6 +4,7 @@ import { ContentService } from '../content/contentService';
 import { logger } from '../../logger';
 
 const LOG_SCOPE = 'SessionService';
+const MAX_RECENT_SEEN_IDS = 5_000;
 import { normalizeOptionsToArray } from '../../utils/questionDataNormalizer';
 import { resolveCorrectAnswerIndex } from '../../answerLetterMap';
 import { withTimeout } from '../../timeout';
@@ -161,6 +162,8 @@ export class SessionService {
         this.prisma.userQuestionSeen.findMany({
           where: { userId },
           select: { questionId: true, questionType: true },
+          orderBy: { lastSeenAt: 'desc' },
+          take: MAX_RECENT_SEEN_IDS,
         }),
         this.prisma.preGeneratedQuestion.count({
           where: { usedAt: null },

--- a/lib/utils/dataLoader.ts
+++ b/lib/utils/dataLoader.ts
@@ -165,6 +165,9 @@ export async function loadLabCases(getToken?: () => Promise<string | null>): Pro
   }
 
   try {
+    if (!getToken) {
+      return [];
+    }
     const apiUrl = getApiEndpoint(API_ENDPOINTS.LABS_CASES);
 
     // Build headers with auth token if available
@@ -172,12 +175,11 @@ export async function loadLabCases(getToken?: () => Promise<string | null>): Pro
       'Content-Type': 'application/json',
     };
 
-    if (getToken) {
-      const token = await getToken();
-      if (token) {
-        headers['Authorization'] = `Bearer ${token}`;
-      }
+    const token = await getToken();
+    if (!token) {
+      return [];
     }
+    headers['Authorization'] = `Bearer ${token}`;
 
     const response = await fetch(apiUrl, { headers });
 

--- a/services/core/mainSessionService.ts
+++ b/services/core/mainSessionService.ts
@@ -29,11 +29,17 @@ interface PoolStatus {
   needsGeneration: boolean;
 }
 
+interface SessionEmptyState {
+  code: string;
+  message: string;
+}
+
 // Full session response
 interface SessionResponse {
   questions: Question[];
   analytics: SessionAnalytics;
   poolStatus: PoolStatus;
+  emptyState?: SessionEmptyState;
 }
 
 // Session state for tracking
@@ -158,13 +164,24 @@ export async function fetchSessionQuestions(
       }
 
       if (!response.ok) {
+        let errorMessage = `API error: ${response.status}`;
+        try {
+          const payload = await response.json();
+          if (payload && typeof payload === 'object') {
+            const typed = payload as { error?: string; message?: string };
+            errorMessage = typed.message || typed.error || errorMessage;
+          }
+        } catch {
+          // Ignore JSON parse errors and keep status-based message.
+        }
+
         // If 503 and not last attempt, retry
         if (response.status === 503 && attempt < maxRetries) {
           console.warn(`[SessionService] API 503 (attempt ${attempt}), retrying...`);
           await new Promise(resolve => setTimeout(resolve, retryDelay * attempt));
           continue;
         }
-        throw new Error(`API error: ${response.status}`);
+        throw new Error(errorMessage);
       }
 
       const data = await response.json();
@@ -194,6 +211,7 @@ export async function fetchSessionQuestions(
         questions,
         analytics: data.analytics,
         poolStatus: data.poolStatus,
+        emptyState: data.emptyState,
       };
     } catch (error) {
       lastError = error as Error;
@@ -205,6 +223,28 @@ export async function fetchSessionQuestions(
   }
 
   console.error('[SessionService] All API fetch attempts failed, using fallback:', lastError);
+  if (settings.simulationStrict) {
+    return {
+      questions: [],
+      analytics: {
+        questionsServed: 0,
+        fromPool: 0,
+        fromMain: 0,
+        generated: 0,
+        fromSeeds: 0,
+        avgDifficulty: 0,
+        systemDistribution: {},
+      },
+      poolStatus: {
+        available: 0,
+        needsGeneration: false,
+      },
+      emptyState: {
+        code: 'SESSION_SERVICE_UNAVAILABLE',
+        message: 'Simulation is temporarily unavailable. Please try again shortly.',
+      },
+    };
+  }
   return fallbackQuestionFetch(settings, count, token);
 }
 
@@ -237,6 +277,13 @@ async function fallbackQuestionFetch(
         available: 0,
         needsGeneration: true,
       },
+      emptyState:
+        questions.length === 0
+          ? {
+              code: 'SESSION_FALLBACK_EMPTY',
+              message: 'No questions matched this session configuration. Try a broader focus or try again later.',
+            }
+          : undefined,
     };
   } catch (fallbackError) {
     console.error('[SessionService] Fallback also failed:', fallbackError);
@@ -254,6 +301,10 @@ async function fallbackQuestionFetch(
       poolStatus: {
         available: 0,
         needsGeneration: true,
+      },
+      emptyState: {
+        code: 'SESSION_FALLBACK_UNAVAILABLE',
+        message: 'Question service is temporarily unavailable. Please try again shortly.',
       },
     };
   }

--- a/services/questionService.ts
+++ b/services/questionService.ts
@@ -254,7 +254,11 @@ async function fetchFromPool(
   if (token && token.trim().length > 0) {
     headers.Authorization = `Bearer ${token}`;
   } else {
-    console.warn('[QuestionService] No auth token provided to fetchFromPool - relying on session cookies');
+    console.warn('[QuestionService] No auth token provided to fetchFromPool - skipping pool request');
+    return {
+      questions: [],
+      poolStatus: { available: 0, needsGeneration: false, threshold: 50 },
+    };
   }
 
   try {


### PR DESCRIPTION
## Summary
- harden signed-in bootstrap routes around internal user resolution and missing-user recovery
- make strict simulation launch return structured empty/degraded states instead of opaque session failures
- reduce startup timeout risk and fail-soft noncritical study bootstrap widgets

## Verification
- npx prisma validate
- npx prisma generate
- npm run typecheck:ci
- npx vitest run functions/api/user/profile.test.ts functions/api/srs/due.test.ts functions/api/sync.test.ts
- npm run build

## Incident docs
- docs/debug/production-study-session-triage.md
- docs/debug/production-study-session-fix-summary.md