### PR TITLE
fix: use direct database url for deploy migrations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 # Deploy to Cloudflare Pages ONLY after CI passes.
 # Triggers: (a) when CI workflow succeeds on main, or (b) manual dispatch.
-# Requires secrets: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID
+# Requires secrets: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID, DATABASE_URL, DIRECT_DATABASE_URL
 # Project name: panacea (Workers & Pages) — matches wrangler.toml
 name: Deploy to Cloudflare Pages
 
@@ -51,6 +51,7 @@ jobs:
         run: npx prisma migrate deploy
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DIRECT_DATABASE_URL: ${{ secrets.DIRECT_DATABASE_URL }}
 
       - name: Core type check
         run: npm run typecheck:ci


### PR DESCRIPTION
## Summary
- pass `DIRECT_DATABASE_URL` into the deploy workflow migration step
- align GitHub Actions with `prisma.config.ts`, which already prefers `DIRECT_DATABASE_URL` for CLI migration commands
- document the additional required secret in the workflow header

## Why
Manual deploy run `24535202658` failed in `Run database migrations` with `P1001` because CI was trying to migrate through the Prisma Accelerate URL instead of a direct connection.

## Verification
- inspected `prisma.config.ts` and confirmed CLI datasource precedence is `DIRECT_DATABASE_URL || DATABASE_URL`
- reproduced deploy failure and confirmed it occurs before build/deploy at the migration step