### PR TITLE
fix: correct study session question import path

### DIFF
--- a/functions/api/study/session/[sessionId]/questions.ts
+++ b/functions/api/study/session/[sessionId]/questions.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 import { authenticatedEndpoint } from '../../../_shared/middleware';
 import { createEdgePrismaClient, safePrismaDisconnect } from '../../../_shared/prisma-edge';
 import { createEndpointLogger } from '../../../_shared/secureLogger';
-import { normalizeSessionQuestion } from '../../../../lib/sessionGeneration';
+import { normalizeSessionQuestion } from '../../../../../lib/sessionGeneration';
 
 const ParamsSchema = z.object({
   sessionId: z.string().min(1, 'Missing session id'),


### PR DESCRIPTION
## Summary
- fix the Pages Functions import path in `functions/api/study/session/[sessionId]/questions.ts`
- align the relative import with the actual location of `lib/sessionGeneration.ts`

## Why
Manual deploy run `24535385546` failed during the Cloudflare Pages deploy step because Wrangler could not resolve `../../../../lib/sessionGeneration` from the function bundle.

## Verification
- confirmed the corrected relative path resolves to `/lib/sessionGeneration.ts` in a clean clone