### PR TITLE
fix: app-code stabilization — typecheck, lint, dev import paths

### DIFF
--- a/.cursor/memory/validation-history.md
+++ b/.cursor/memory/validation-history.md
@@ -1,0 +1,28 @@
+# Validation history
+
+## 2026-07-09 — `cursor/app-stabilization-984e`
+
+**Scope:** Typecheck, lint, missing dev imports, legacy routes restore.
+
+| Command | Before | After |
+|---------|--------|-------|
+| `npm run typecheck` | 2 errors (`renderStructuredRationale.ts`) | **PASS** |
+| `npm run lint` | 3 errors (`no-empty`), 251 warnings | **PASS** (0 errors, 251 warnings) |
+| `npm run build` | (not recorded) | **PASS** |
+| `npm run test:critical` | (not recorded) | **PASS** — 6 files, 143 tests |
+| `npm test` | (not recorded) | **PASS** — 527 files, 9849 passed, 1 skipped |
+| `npm run dev:server` | `Cannot find module './routes'` | **PASS** with `.env` — routes register, server listens :3001 |
+| `npm run dev:wrangler` | Missing `tokenMatchCache` import | **Compiles Worker**; runtime needs `DATABASE_URL` in env |
+| Module smoke: `routes/index.ts` | `ERR_MODULE_NOT_FOUND` via trash re-export | **PASS** after full `routes/` restore |
+| Module smoke: `semantic-cache.ts` | Missing `@/lib/services/tokenMatchCache` | **PASS** |
+
+**Files changed (app code):**
+
+- `lib/study/renderStructuredRationale.ts`
+- `lib/nccpa-question-weighting.ts`
+- `services/medicalComplianceService.ts`
+- `lib/services/tokenMatchCache.ts` (restored)
+- `lib/services/tokenMatchCache.test.ts` (added)
+- `routes/*` (restored from `_trash/old-routes/`)
+
+**Agent infrastructure touched:** Documentation only (this file, `docs/cursor-followup-issues.md`).

--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,8 @@ playwright/*.json
 !lib/tokens/**
 !components/dashboard/adaptive/model/visualTokens.ts
 !components/dashboard/adaptive/visuals/VisualTokenProvider.tsx
+!lib/services/tokenMatchCache.ts
+!lib/services/tokenMatchCache.test.ts
 *auth_token*
 *access_token*
 *refresh_token*
@@ -224,7 +226,6 @@ heapdump-*.heapsnapshot
 *.quoted
 *.new
 *_backup
-.cursor/memory/
 .ai/
 
 # Temporary validation and conversion scripts
@@ -296,7 +297,9 @@ typecheck-errors.txt
 .roomodes
 .amazonq/
 .cline/
-.cursor/
+.cursor/*
+!.cursor/memory/
+!.cursor/memory/**
 .kiro/
 .roo/
 mcp_config.json

--- a/docs/cursor-followup-issues.md
+++ b/docs/cursor-followup-issues.md
@@ -1,0 +1,62 @@
+# Cursor follow-up issues
+
+Tracking stabilization blockers and follow-up work from app-code PRs.
+
+## Resolved in `cursor/app-stabilization-984e`
+
+### Typecheck: `renderStructuredRationale.ts` union indexing
+
+- **Files:** `lib/study/renderStructuredRationale.ts`
+- **Error:** `TS2345` — `keyof StructuredRationaleInput` includes array/object fields passed to `cleanText(string)`.
+- **Fix:** Added `getWhyIncorrectText()` with an exhaustive switch over option letters `A`–`E`.
+- **Command:** `npm run typecheck` — **passes**
+
+### Lint: three `no-empty` violations
+
+- **Files:** `lib/nccpa-question-weighting.ts`, `services/medicalComplianceService.ts`
+- **Fix:** Replaced empty example/stub blocks with intentional `void` usage and comments (no behavior change).
+- **Command:** `npm run lint` — **0 errors** (251 pre-existing warnings remain)
+
+### Missing module: `lib/services/tokenMatchCache.ts`
+
+- **Symptom:** `npm run dev:wrangler` / `functions/api/_shared/semantic-cache.ts` failed to resolve `@/lib/services/tokenMatchCache`.
+- **Root cause:** Pure helper module was removed; Edge wrapper still imported it.
+- **Fix:** Restored `lib/services/tokenMatchCache.ts` from git history (`d135f6bc`) and added `lib/services/tokenMatchCache.test.ts`. Added `.gitignore` exceptions — the `*token*` secret pattern had been blocking these filenames.
+- **Command:** `node --import tsx -e "import './functions/api/_shared/semantic-cache.ts'"` — **loads**
+
+### Missing legacy Express routes (`./routes`)
+
+- **Symptom:** `npm run dev:server` / `dev:all` failed — `server.ts` imports `./routes`, directory missing after trash move.
+- **Root cause:** Route modules moved to `_trash/old-routes/`; relative imports (`../lib/prisma`) break when only re-exporting from trash.
+- **Fix:** Restored full `routes/` directory from `_trash/old-routes/` (local dev only; production uses `functions/api/`).
+- **Command:** `npm run dev:server` (with `.env` present) — **starts and registers routes**
+
+---
+
+## Open / environment blockers
+
+### Local dev requires `.env`
+
+- **Commands affected:** `npm run dev:server`, `npm run dev:all`, `npm run dev:wrangler`
+- **Error:** `node: .env: not found` or Prisma `DATABASE_URL environment variable is not set`
+- **Not an app-code bug:** Cloud/agent environments without secrets cannot fully boot DB-backed servers.
+- **Follow-up:** Document required `.env` keys in onboarding; optional `.env.example` refresh PR.
+
+### Legacy Express routes vs Cloudflare Functions drift
+
+- **Path:** `routes/` (local) vs `functions/api/` (production)
+- **Risk:** Legacy routes may lag Edge handlers in auth/features.
+- **Follow-up:** Audit dormant routes (`/api/games`, `/api/pearls`, `/api/adaptive`) for deletion or explicit deprecation banner in `server.ts` startup log.
+
+### Lint warnings (251 `no-restricted-syntax` hex color warnings)
+
+- **Scope:** Pre-existing across pages/types/services
+- **Follow-up:** Separate token-migration PR; out of scope for stabilization.
+
+---
+
+## Recommended next PRs
+
+1. **`.env.example` sync** — list minimum vars for `dev:server`, `dev:wrangler`, and Vite.
+2. **Legacy routes retirement plan** — delete or quarantine `_trash/old-routes/` once shim is canonical in `routes/`.
+3. **Hex token lint cleanup** — migrate raw hex in pages/types to CSS variables / `lib/tokens`.

--- a/lib/nccpa-question-weighting.ts
+++ b/lib/nccpa-question-weighting.ts
@@ -373,16 +373,16 @@ export function getDistributionSummary(sessionSize: number = 40): string {
 /**
  * Sample usage example
  */
-export function exampleUsage() {
-
-  // 40-question session
+export function exampleUsage(): void {
   const sessionSize = 40;
   const distribution = calculateSessionDistribution(sessionSize);
+  // Documentation example: distribution maps organ systems to question counts.
+  void [...distribution.entries()].reduce<Record<string, number>>((acc, [system, count]) => {
+    acc[system] = count;
+    return acc;
+  }, {});
 
-  for (const [system, count] of distribution) {
-  }
-
-  const selected = selectWeightedSystems(5);
+  void selectWeightedSystems(5);
 
   const testCounts = new Map([
     ['CV', 5],
@@ -391,5 +391,6 @@ export function exampleUsage() {
   ]);
   const validation = validateSessionDistribution(testCounts, 40);
   if (!validation.valid) {
+    void validation.violations;
   }
 }

--- a/lib/services/tokenMatchCache.test.ts
+++ b/lib/services/tokenMatchCache.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import {
+  JACCARD_SIMILARITY_THRESHOLD,
+  jaccardSimilarity,
+  normalizeMedicalTerms,
+  tokenizeForCache,
+} from './tokenMatchCache';
+
+describe('tokenMatchCache', () => {
+  it('tokenizes and strips punctuation', () => {
+    expect(tokenizeForCache('Heart-Attack!')).toEqual(['heart', 'attack']);
+  });
+
+  it('returns 1 for identical token sets', () => {
+    expect(jaccardSimilarity(['mi', 'chest'], ['mi', 'chest'])).toBe(1);
+  });
+
+  it('returns 0 for disjoint token sets', () => {
+    expect(jaccardSimilarity(['mi'], ['copd'])).toBe(0);
+  });
+
+  it('normalizes synonymous medical terms', () => {
+    expect(normalizeMedicalTerms('heart attack')).toBe('mi');
+    expect(normalizeMedicalTerms('myocardial infarction')).toBe('mi');
+  });
+
+  it('uses the documented similarity threshold', () => {
+    expect(JACCARD_SIMILARITY_THRESHOLD).toBe(0.85);
+  });
+});

--- a/lib/services/tokenMatchCache.ts
+++ b/lib/services/tokenMatchCache.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure token-match cache helpers (Edge-safe, no Prisma, no Node APIs).
+ *
+ * Extracted from the deprecated lib/services/semanticCacheService.ts per its
+ * 2026-05-22 deprecation note. functions/api/_shared/semantic-cache.ts wraps
+ * these with Prisma calls for the Edge runtime. NOT a true semantic cache —
+ * Jaccard token overlap, not vector embeddings.
+ */
+
+export interface TokenCacheQuery {
+  queryText: string;
+  questionType: string;
+  system?: string;
+  difficulty?: string;
+}
+
+export interface TokenCacheMatch {
+  question: unknown;
+  similarity: number;
+  cacheId: string;
+}
+
+/** Similarity threshold for cache hits (0-1). 0.85 = 85% token overlap. */
+export const JACCARD_SIMILARITY_THRESHOLD = 0.85;
+
+/** Lowercase, strip punctuation, split on whitespace. */
+export function tokenizeForCache(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s]/g, ' ')
+    .split(/\s+/)
+    .filter((t) => t.length > 0);
+}
+
+/** Jaccard similarity between two token lists (set intersection / union). */
+export function jaccardSimilarity(tokens1: string[], tokens2: string[]): number {
+  const set1 = new Set(tokens1);
+  const set2 = new Set(tokens2);
+
+  const intersection = new Set([...set1].filter((x) => set2.has(x)));
+  const union = new Set([...set1, ...set2]);
+
+  if (union.size === 0) return 0;
+  return intersection.size / union.size;
+}
+
+/**
+ * Normalize medical terminology variants to canonical forms so near-identical
+ * queries ("heart attack" vs "myocardial infarction") hit the same cache entry.
+ */
+export function normalizeMedicalTerms(text: string): string {
+  const normalizations: Record<string, string> = {
+    pericarditis: 'pericarditis',
+    'acute pericarditis': 'pericarditis',
+    'pericardial inflammation': 'pericarditis',
+    'myocardial infarction': 'mi',
+    'heart attack': 'mi',
+    mi: 'mi',
+    stemi: 'mi',
+    nstemi: 'mi',
+    'diabetes mellitus': 'diabetes',
+    diabetes: 'diabetes',
+    'type 2 diabetes': 'diabetes',
+    t2dm: 'diabetes',
+    'congestive heart failure': 'chf',
+    'heart failure': 'chf',
+    chf: 'chf',
+    copd: 'copd',
+    'chronic obstructive pulmonary disease': 'copd',
+    pneumonia: 'pneumonia',
+    'community acquired pneumonia': 'pneumonia',
+    cap: 'pneumonia',
+  };
+
+  let normalized = text.toLowerCase();
+
+  for (const [variant, canonical] of Object.entries(normalizations)) {
+    const regex = new RegExp(`\\b${variant}\\b`, 'gi');
+    normalized = normalized.replace(regex, canonical);
+  }
+
+  return normalized;
+}

--- a/lib/study/renderStructuredRationale.ts
+++ b/lib/study/renderStructuredRationale.ts
@@ -26,6 +26,29 @@ export interface StructuredRationaleInput {
 }
 
 const OPTION_LETTERS = ['A', 'B', 'C', 'D', 'E'] as const;
+type OptionLetter = (typeof OPTION_LETTERS)[number];
+
+function getWhyIncorrectText(
+  rationale: StructuredRationaleInput,
+  letter: OptionLetter
+): string | undefined {
+  switch (letter) {
+    case 'A':
+      return rationale.whyIncorrectA;
+    case 'B':
+      return rationale.whyIncorrectB;
+    case 'C':
+      return rationale.whyIncorrectC;
+    case 'D':
+      return rationale.whyIncorrectD;
+    case 'E':
+      return rationale.whyIncorrectE;
+    default: {
+      const _exhaustive: never = letter;
+      return _exhaustive;
+    }
+  }
+}
 
 /**
  * Render the full structured rationale into a single formatted text block.
@@ -49,8 +72,7 @@ export function renderStructuredRationale(rationale: StructuredRationaleInput): 
   // 3. Why Each Distractor Is Wrong (teaching moment)
   const whyIncorrectLines: string[] = [];
   for (const letter of OPTION_LETTERS) {
-    const key = `whyIncorrect${letter}` as keyof StructuredRationaleInput;
-    const text = cleanText(rationale[key]);
+    const text = cleanText(getWhyIncorrectText(rationale, letter));
     if (text) {
       whyIncorrectLines.push(`Why option ${letter} is incorrect: ${text}`);
     }
@@ -101,8 +123,7 @@ export function renderDistractorRationale(
 
   for (let i = 0; i < OPTION_LETTERS.length; i++) {
     const letter = OPTION_LETTERS[i]!;
-    const key = `whyIncorrect${letter}` as keyof StructuredRationaleInput;
-    const text = cleanText(rationale[key]);
+    const text = cleanText(getWhyIncorrectText(rationale, letter));
     if (!text) continue;
 
     const isUserChoice = userAnswerIndex !== undefined && i === userAnswerIndex;

--- a/routes/adaptive.ts
+++ b/routes/adaptive.ts
@@ -1,0 +1,106 @@
+/**
+ * Adaptive Learning Router
+ *
+ * Public API for accessing:
+ * - Smart Recommendations
+ * - User Strength Profile (Knowledge Graph)
+ */
+
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../lib/middleware/clerkAuth';
+import {
+  generateRecommendations,
+  getNextBestAction,
+  getUserStrengthProfile,
+} from '../lib/services/adaptiveLearning';
+import { prisma } from '../lib/prisma';
+
+const router = Router();
+
+/**
+ * GET /api/adaptive/recommendations
+ * Generates and returns current study recommendations
+ */
+router.get('/recommendations', requireAuth, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = req.auth?.userId;
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    const result = await generateRecommendations(userId);
+    res.json(result);
+  } catch (error) {
+    console.error('Error in adaptive recommendations:', error);
+    res.status(500).json({ error: 'Failed to generate recommendations' });
+  }
+});
+
+/**
+ * GET /api/adaptive/next-action
+ * Quick endpoint for "Just tell me what to do" button
+ */
+router.get('/next-action', requireAuth, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = req.auth?.userId;
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    const action = await getNextBestAction(userId);
+    res.json({ action });
+  } catch (error) {
+    console.error('Error in next-action:', error);
+    res.status(500).json({ error: 'Failed to determine next action' });
+  }
+});
+
+/**
+ * GET /api/adaptive/profile
+ * Returns the raw strength profile for visualization
+ */
+router.get('/profile', requireAuth, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = req.auth?.userId;
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    const profile = await getUserStrengthProfile(userId);
+    res.json({ profile });
+  } catch (error) {
+    console.error('Error fetching profile:', error);
+    res.status(500).json({ error: 'Failed to fetch learning profile' });
+  }
+});
+
+/**
+ * POST /api/adaptive/feedback
+ * Log user feedback on a recommendation (e.g. "Too easy", "Not now")
+ */
+router.post('/feedback', requireAuth, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = req.auth?.userId;
+    const { recommendationId, action } = req.body; // action: 'completed' | 'dismissed'
+
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    await prisma.studyRecommendation.updateMany({
+      where: { id: recommendationId, userId },
+      data: {
+        status: action === 'dismissed' ? 'dismissed' : 'completed',
+        completedAt: new Date(),
+      },
+    });
+
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Error handling feedback:', error);
+    res.status(500).json({ error: 'Failed to record feedback' });
+  }
+});
+
+export default router;

--- a/routes/ai.ts
+++ b/routes/ai.ts
@@ -1,0 +1,15 @@
+/**
+ * AI Routes (Legacy - local dev only)
+ *
+ * Gemini proxy has been migrated to Cloudflare Pages Functions:
+ * - Non-streaming: POST /api/gemini (see functions/api/gemini/index.ts)
+ * - Streaming: POST /api/gemini/stream (see functions/api/gemini/stream.ts)
+ *
+ * This router is kept for potential future AI routes; /geminiProxy was removed.
+ */
+
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/routes/analytics.ts
+++ b/routes/analytics.ts
@@ -1,0 +1,261 @@
+/**
+ * Analytics Routes
+ *
+ * Handles analytics reporting (reactions, weakness patterns, confusion pairs)
+ * and data retrieval (performance deltas).
+ * Extracted from server.ts for modularity.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { Router, Request, Response } from 'express';
+import { prisma } from '../lib/prisma';
+import { requireAuth, AuthenticatedRequest } from '../lib/middleware/clerkAuth';
+import { validateRequired, validateEnum } from '../lib/middleware/validation';
+import crypto from 'crypto';
+
+const router = Router();
+
+// Store reaction to explanation helpfulness
+router.post(
+  '/reactions',
+  validateRequired(['questionId', 'reaction']),
+  validateEnum('reaction', ['helpful', 'not_helpful']),
+  async (req: Request, res: Response) => {
+    try {
+      const { questionId, reaction, userId } = req.body;
+
+      if (process.env.DATABASE_URL) {
+        await prisma.explanationReaction.create({
+          data: {
+            id: uuidv4(),
+            questionId,
+            reaction,
+            userId: userId || null,
+          },
+        });
+      }
+
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Failed to store reaction:', error);
+      res.status(500).json({ success: false, error: 'Failed to store reaction' });
+    }
+  }
+);
+
+// Track user weakness patterns
+router.post(
+  '/weakness',
+  validateRequired(['conditionId', 'wasCorrect']),
+  async (req: Request, res: Response) => {
+    try {
+      const { conditionId, wasCorrect, userId } = req.body;
+
+      if (process.env.DATABASE_URL && userId) {
+        await prisma.weaknessPattern.create({
+          data: {
+            id: uuidv4(),
+            userId,
+            conditionId,
+            wasCorrect,
+          },
+        });
+      }
+
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Failed to store weakness pattern:', error);
+      res.status(500).json({ success: false, error: 'Failed to store weakness pattern' });
+    }
+  }
+);
+
+// Track diagnostic confusion patterns
+router.post(
+  '/confusion',
+  validateRequired(['correctCondition', 'selectedCondition']),
+  async (req: Request, res: Response) => {
+    try {
+      const { correctCondition, selectedCondition, userId } = req.body;
+
+      if (process.env.DATABASE_URL) {
+        // Update or create confusion pair
+        const existingPair = await prisma.confusionPair.findUnique({
+          where: {
+            userId_realCondition_mistakenFor: {
+              userId: userId || null,
+              realCondition: correctCondition,
+              mistakenFor: selectedCondition,
+            },
+          },
+        });
+
+        if (existingPair) {
+          await prisma.confusionPair.update({
+            where: { id: existingPair.id },
+            data: {
+              count: { increment: 1 },
+              lastOccurrence: new Date(),
+            },
+          });
+        } else {
+          await prisma.confusionPair.create({
+            data: {
+              id: uuidv4(),
+              userId: userId || null,
+              realCondition: correctCondition,
+              mistakenFor: selectedCondition,
+              count: 1,
+            },
+          });
+        }
+      }
+
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Failed to store confusion pattern:', error);
+      res.status(500).json({ success: false, error: 'Failed to store confusion pattern' });
+    }
+  }
+);
+
+// SOAP Note grading analytics
+router.post('/soap-note', async (req: Request, res: Response) => {
+  try {
+    const { caseId, totalScore, breakdown, userId } = req.body;
+
+    if (!caseId || typeof totalScore !== 'number' || !breakdown) {
+      res.status(400).json({ success: false, error: 'Missing required analytics fields' });
+      return;
+    }
+
+    if (process.env.DATABASE_URL) {
+      try {
+        // Optional: only persist if such a model exists in the schema (it should)
+        // @ts-ignore - Ignoring potential type error if model missing in generated client
+        if (prisma.soapNoteGradingEvent) {
+          // @ts-ignore
+          await prisma.soapNoteGradingEvent.create({
+            data: {
+              id: uuidv4(),
+              userId: userId || null,
+              caseId,
+              totalScore,
+              breakdown,
+            },
+          });
+        }
+      } catch (dbError) {
+        console.warn('SOAP analytics DB persistence skipped:', dbError);
+      }
+    }
+
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Failed to store SOAP grading analytics:', error);
+    res.status(500).json({ success: false, error: 'Failed to store SOAP grading analytics' });
+  }
+});
+
+/**
+ * GET /performance-deltas
+ * Computes performance deltas for a user compared to their cohort.
+ */
+router.get(
+  '/performance-deltas',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const userId = req.auth?.userId;
+      if (!userId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      const cohortId = req.query.cohortId as string | undefined;
+
+      // Use dynamic import to avoid circular cycles if service imports routes (unlikely but safe)
+      const { generatePeerComparison, getCohortBenchmarks } =
+        await import('../lib/services/analyticsService');
+
+      const peerComparison = await generatePeerComparison(userId, cohortId);
+
+      let effectiveCohortId = cohortId;
+      if (!effectiveCohortId) {
+        const userCohort = await prisma.cohortMember.findFirst({
+          where: { userId },
+          select: { cohortId: true },
+        });
+        effectiveCohortId = userCohort?.cohortId || 'global';
+      }
+
+      const cohortBenchmarks = await getCohortBenchmarks(effectiveCohortId!);
+
+      const p90Map = new Map<string, number>();
+      for (const benchmark of cohortBenchmarks) {
+        p90Map.set(benchmark.system, benchmark.p90Accuracy);
+      }
+
+      const totalAttempts = peerComparison.reduce((sum, item) => sum + item.totalQuestions, 0);
+      const averagePercentile =
+        peerComparison.length > 0
+          ? peerComparison.reduce((sum, item) => sum + item.userPercentile, 0) /
+            peerComparison.length
+          : 0;
+
+      const systems = peerComparison.map((item) => {
+        const cohortP90 = p90Map.get(item.system) || item.cohortAverage;
+
+        const cohortDelta = item.userAccuracy - item.cohortAverage;
+        const topPerformerGap = cohortP90 - item.userAccuracy;
+        const yieldScore = topPerformerGap * (item.totalQuestions / 10);
+        const isInsufficientData = item.totalQuestions < 10;
+
+        let status: 'strength' | 'average' | 'weakness' | 'critical';
+        if (isInsufficientData) {
+          status = cohortDelta >= 0 ? 'average' : 'weakness';
+        } else if (cohortDelta >= 10) {
+          status = 'strength';
+        } else if (cohortDelta >= -5) {
+          status = 'average';
+        } else if (cohortDelta >= -15) {
+          status = 'weakness';
+        } else {
+          status = 'critical';
+        }
+
+        return {
+          name: item.system,
+          accuracy: Math.round(item.userAccuracy * 10) / 10,
+          cohortAverage: Math.round(item.cohortAverage * 10) / 10,
+          cohortP90: Math.round(cohortP90 * 10) / 10,
+          cohortDelta: Math.round(cohortDelta * 10) / 10,
+          topPerformerGap: Math.round(topPerformerGap * 10) / 10,
+          yieldScore: Math.round(yieldScore * 10) / 10,
+          status,
+          isInsufficientData,
+        };
+      });
+
+      systems.sort((a, b) => b.yieldScore - a.yieldScore);
+
+      res.json({
+        success: true,
+        data: {
+          userTotalAttempts: totalAttempts,
+          overallPercentile: Math.round(averagePercentile * 10) / 10,
+          systems,
+        },
+      });
+    } catch (error) {
+      console.error('Failed to compute performance deltas:', error);
+      res.status(500).json({
+        success: false,
+        error: 'Failed to compute performance deltas',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }
+);
+
+export default router;

--- a/routes/audit.ts
+++ b/routes/audit.ts
@@ -1,0 +1,169 @@
+import { Router } from 'express';
+import { prisma } from '../lib/prisma';
+
+const router = Router();
+
+// Helper to convert BigInt to Number for JSON serialization
+const toBigIntSafe = (obj: any): any => {
+  if (typeof obj === 'bigint') return Number(obj);
+  if (Array.isArray(obj)) return obj.map(toBigIntSafe);
+  if (obj !== null && typeof obj === 'object') {
+    return Object.fromEntries(
+      Object.entries(obj).map(([k, v]) => [k, toBigIntSafe(v)])
+    );
+  }
+  return obj;
+};
+
+router.get('/content-audit', async (req, res) => {
+  try {
+    const results: Record<string, any> = {};
+
+    // 1. Questions by validation status
+    try {
+      const data = await prisma.$queryRaw`
+        SELECT "validationStatus", COUNT(*) as count FROM "PreGeneratedQuestion" GROUP BY "validationStatus"
+      `;
+      results.q1_by_status = toBigIntSafe(data);
+    } catch (e) {
+      results.q1_by_status = { error: String(e).substring(0, 100) };
+    }
+
+    // 2. Questions by system
+    try {
+      const data = await prisma.$queryRaw`
+        SELECT "system", COUNT(*) as count FROM "PreGeneratedQuestion" WHERE "system" IS NOT NULL GROUP BY "system" ORDER BY COUNT(*) DESC LIMIT 20
+      `;
+      results.q2_by_system = toBigIntSafe(data);
+    } catch (e) {
+      results.q2_by_system = { error: String(e).substring(0, 100) };
+    }
+
+    // 3. Total conditions with questions
+    try {
+      const data = await prisma.$queryRaw`
+        SELECT COUNT(DISTINCT "conditionId") as count FROM "PreGeneratedQuestion" WHERE "conditionId" IS NOT NULL
+      `;
+      results.q3_conditions_with_questions = toBigIntSafe(data);
+    } catch (e) {
+      results.q3_conditions_with_questions = { error: String(e).substring(0, 100) };
+    }
+
+    // 4. Total conditions in database
+    try {
+      const data = await prisma.$queryRaw`
+        SELECT COUNT(*) as count FROM "Condition"
+      `;
+      results.q4_total_conditions = toBigIntSafe(data);
+    } catch (e) {
+      results.q4_total_conditions = { error: String(e).substring(0, 100) };
+    }
+
+    // 5. UserProgress records
+    try {
+      const data = await prisma.$queryRaw`
+        SELECT COUNT(*) as total, COUNT(CASE WHEN "nextReviewAt" IS NOT NULL THEN 1 END) as with_next_review FROM "UserProgress"
+      `;
+      results.q5_user_progress = toBigIntSafe(data);
+    } catch (e) {
+      results.q5_user_progress = { error: String(e).substring(0, 100) };
+    }
+
+    // 6. ReviewLog entries
+    try {
+      const data = await prisma.$queryRaw`
+        SELECT COUNT(*) as total, MIN("createdAt") as first_review, MAX("createdAt") as last_review FROM "ReviewLog"
+      `;
+      results.q6_review_log = toBigIntSafe(data);
+    } catch (e) {
+      results.q6_review_log = { error: String(e).substring(0, 100) };
+    }
+
+    // 7. QuestionAttempt data
+    try {
+      const data = await prisma.$queryRaw`
+        SELECT COUNT(*) as total, COUNT(CASE WHEN "wasCorrect" = true THEN 1 END) as correct FROM "QuestionAttempt"
+      `;
+      results.q7_attempts = toBigIntSafe(data);
+    } catch (e) {
+      results.q7_attempts = { error: String(e).substring(0, 100) };
+    }
+
+    // 8. Drug count
+    try {
+      const data = await prisma.$queryRaw`
+        SELECT COUNT(*) as count FROM "Drug"
+      `;
+      results.q8_drugs = toBigIntSafe(data);
+    } catch (e) {
+      results.q8_drugs = { error: String(e).substring(0, 100) };
+    }
+
+    // 9. Questions with no condition link
+    try {
+      const data = await prisma.$queryRaw`
+        SELECT COUNT(*) as count FROM "PreGeneratedQuestion" WHERE "conditionId" IS NULL
+      `;
+      results.q9_orphaned = toBigIntSafe(data);
+    } catch (e) {
+      results.q9_orphaned = { error: String(e).substring(0, 100) };
+    }
+
+    // 10. Content by difficulty
+    try {
+      const data = await prisma.$queryRaw`
+        SELECT "difficulty", COUNT(*) as count FROM "PreGeneratedQuestion" GROUP BY "difficulty" ORDER BY COUNT(*) DESC
+      `;
+      results.q10_by_difficulty = toBigIntSafe(data);
+    } catch (e) {
+      results.q10_by_difficulty = { error: String(e).substring(0, 100) };
+    }
+
+    // 11. Questions with empty/null data
+    try {
+      const data = await prisma.$queryRaw`
+        SELECT COUNT(*) as count FROM "PreGeneratedQuestion" WHERE "questionData" IS NULL OR "questionData"::text = '{}' OR "questionData"::text = 'null'
+      `;
+      results.q11_empty_questions = toBigIntSafe(data);
+    } catch (e) {
+      results.q11_empty_questions = { error: String(e).substring(0, 100) };
+    }
+
+    // 12. FSRS parameters (may not exist)
+    try {
+      const data = await prisma.$queryRaw`
+        SELECT COUNT(*) as count FROM "FSRSParameters"
+      `;
+      results.q12_fsrs_params = toBigIntSafe(data);
+    } catch (e) {
+      results.q12_fsrs_params = { error: 'Table does not exist', code: 'relation_not_exist' };
+    }
+
+    // 13. SessionType distribution in ReviewLog
+    try {
+      const data = await prisma.$queryRaw`
+        SELECT "sessionType", COUNT(*) as count FROM "ReviewLog" GROUP BY "sessionType" ORDER BY COUNT(*) DESC
+      `;
+      results.q13_session_type = toBigIntSafe(data);
+    } catch (e) {
+      results.q13_session_type = { error: String(e).substring(0, 100) };
+    }
+
+    // 14. Question type distribution
+    try {
+      const data = await prisma.$queryRaw`
+        SELECT "questionType", COUNT(*) as count FROM "PreGeneratedQuestion" GROUP BY "questionType" ORDER BY COUNT(*) DESC
+      `;
+      results.q14_question_types = toBigIntSafe(data);
+    } catch (e) {
+      results.q14_question_types = { error: String(e).substring(0, 100) };
+    }
+
+    res.json(results);
+  } catch (error) {
+    console.error('Audit error:', error);
+    res.status(500).json({ error: String(error) });
+  }
+});
+
+export default router;

--- a/routes/buzzwords.ts
+++ b/routes/buzzwords.ts
@@ -1,0 +1,44 @@
+/**
+ * Buzzwords Routes
+ *
+ * Handles all buzzword-related API endpoints.
+ * Extracted from server.ts for modularity.
+ */
+
+import { Router, Request, Response } from 'express';
+import { prisma } from '../lib/prisma';
+
+const router = Router();
+
+// Get all buzzwords
+router.get('/', async (req: Request, res: Response) => {
+  try {
+    const buzzwords = await prisma.buzzword.findMany({
+      orderBy: { buzzword: 'asc' },
+    });
+    res.json(buzzwords);
+  } catch (error) {
+    console.error('Error fetching buzzwords:', error);
+    res.status(500).json({ error: 'Failed to fetch buzzwords' });
+  }
+});
+
+// Get random buzzwords
+router.get('/random', async (req: Request, res: Response) => {
+  try {
+    const count = parseInt(req.query.count as string) || 10;
+
+    const buzzwords = await prisma.$queryRaw`
+      SELECT * FROM "Buzzword"
+      ORDER BY RANDOM()
+      LIMIT ${count}
+    `;
+
+    res.json(buzzwords);
+  } catch (error) {
+    console.error('Error fetching random buzzwords:', error);
+    res.status(500).json({ error: 'Failed to fetch random buzzwords' });
+  }
+});
+
+export default router;

--- a/routes/conditions.ts
+++ b/routes/conditions.ts
@@ -1,0 +1,118 @@
+/**
+ * Conditions Routes
+ *
+ * Handles all condition-related API endpoints.
+ * Extracted from server.ts for modularity.
+ */
+
+import { Router, Response } from 'express';
+import { prisma } from '../lib/prisma';
+import { requireAuth, AuthenticatedRequest } from '../lib/middleware/clerkAuth';
+
+const router = Router();
+
+// Get extended condition details (Anatomy, Special Tests)
+router.get(
+  '/:identifier/extended',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const identifier = req.params.identifier;
+      if (identifier == null || identifier === '') {
+        res.status(400).json({ error: 'Missing or invalid identifier' });
+        return;
+      }
+
+      // 1. Try direct ID match (UUID)
+      let condition = await prisma.condition.findUnique({
+        where: { id: identifier },
+        include: {
+          AnatomyStructure: true,
+          SpecialTest: true,
+          MediaAsset: true,
+        },
+      });
+
+      // 2. If not found, try name match (exact)
+      if (!condition) {
+        const conditions = (await prisma.condition.findMany({
+          where: {
+            name: {
+              equals: identifier.replace(/-/g, ' '),
+              mode: 'insensitive',
+            },
+          },
+          include: {
+            AnatomyStructure: true,
+            SpecialTest: true,
+            MediaAsset: true,
+          },
+        })) as any;
+
+        if (conditions.length > 0) {
+          condition = conditions[0];
+        }
+      }
+
+      // 3. If still not found, try searching with the raw identifier
+      if (!condition) {
+        const conditions = (await prisma.condition.findMany({
+          where: {
+            name: {
+              equals: identifier,
+              mode: 'insensitive',
+            },
+          },
+          include: {
+            AnatomyStructure: true,
+            SpecialTest: true,
+            MediaAsset: true,
+          },
+        })) as any;
+        if (conditions.length > 0) {
+          condition = conditions[0];
+        }
+      }
+
+      if (!condition) {
+        res.status(404).json({ error: 'Condition not found' });
+        return;
+      }
+
+      res.json(condition);
+    } catch (error) {
+      console.error('Error fetching extended condition details:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  }
+);
+
+// Get all conditions from database (Registry replacement)
+// Lightweight conditions endpoint - Returns only essential fields for registry
+router.get('/', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const conditions = await prisma.condition.findMany({
+      where: {
+        status: 'published',
+      },
+      select: {
+        id: true,
+        name: true,
+        system: true,
+        subcategory: true,
+      },
+      orderBy: {
+        name: 'asc',
+      },
+    });
+
+    res.json(conditions);
+  } catch (error) {
+    console.error('[Conditions API] Error fetching conditions:', error);
+    res.status(500).json({
+      error: 'Failed to fetch conditions',
+    });
+  }
+});
+
+export default router;

--- a/routes/content.ts
+++ b/routes/content.ts
@@ -1,0 +1,248 @@
+/**
+ * Content Routes
+ *
+ * Handles all medical content-related API endpoints.
+ * Extracted from server.ts for modularity.
+ */
+
+import { Router, Request, Response } from 'express';
+import { prisma } from '../lib/prisma';
+import { requireAuth, AuthenticatedRequest } from '../lib/middleware/clerkAuth';
+
+const router = Router();
+
+// Get all medical content (Replacement for static JSON file)
+// Public endpoint to allow loading content before auth
+router.get('/all', async (req: Request, res: Response): Promise<void> => {
+  try {
+    const allContent = await prisma.medicalContent.findMany({
+      where: { status: 'published' },
+    });
+
+    // Transform to map format expected by frontend
+    const contentMap: Record<string, unknown> = {};
+    allContent.forEach((item) => {
+      contentMap[item.conditionId] = {
+        conditionId: item.conditionId,
+        condition: item.condition,
+        system: item.system,
+        subcategory: item.subcategory,
+        overview: item.overview,
+        etiologyPathophysiology:
+          [
+            item.etiology ? `**Etiology**\n\n${item.etiology}` : null,
+            item.pathophysiology ? `**Pathophysiology**\n\n${item.pathophysiology}` : null,
+          ]
+            .filter(Boolean)
+            .join('\n\n') || undefined,
+        etiology: item.etiology,
+        pathophysiology: item.pathophysiology,
+        epidemiology: item.epidemiology,
+        symptoms: item.symptoms && item.symptoms.length > 0 ? item.symptoms : undefined,
+        physicalExam:
+          item.physicalExam && item.physicalExam.length > 0 ? item.physicalExam : undefined,
+        examFindings:
+          item.physicalExam && item.physicalExam.length > 0 ? item.physicalExam : undefined,
+        riskFactors: item.riskFactors && item.riskFactors.length > 0 ? item.riskFactors : undefined,
+        complications:
+          item.complications && item.complications.length > 0 ? item.complications : undefined,
+        differentialDiagnosis:
+          item.differentialDiagnosis && item.differentialDiagnosis.length > 0
+            ? item.differentialDiagnosis
+            : undefined,
+        diagnostics: item.diagnostics,
+        treatment: item.treatment,
+        prognosis: item.prognosis,
+        buzzwords: item.buzzwords && item.buzzwords.length > 0 ? item.buzzwords : undefined,
+      };
+    });
+
+    res.json(contentMap);
+  } catch (error) {
+    console.error('Error fetching all content:', error);
+
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+    if (errorMessage.includes('connect') || errorMessage.includes('ECONNREFUSED')) {
+      res.status(503).json({
+        error: 'Database unavailable',
+        message:
+          'Unable to connect to database. Please ensure DATABASE_URL is configured and the database is accessible.',
+        details: errorMessage,
+      });
+      return;
+    }
+
+    res.status(500).json({
+      error: 'Internal server error',
+      message: 'Failed to fetch medical content from database',
+      details: process.env.NODE_ENV === 'development' ? errorMessage : undefined, // pragma: allowlist secret
+    });
+  }
+});
+
+// Single Condition Content Endpoint
+router.get(
+  '/condition/:conditionId',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const { conditionId } = req.params;
+
+      if (!conditionId || typeof conditionId !== 'string' || conditionId.trim() === '') {
+        res.status(400).json({
+          error: 'Invalid request',
+          message: 'conditionId parameter is required and must be a valid string',
+        });
+        return;
+      }
+
+      const sanitizedId = conditionId.trim().replace(/[<>"'`;]/g, '');
+
+      const content = await prisma.medicalContent.findFirst({
+        where: {
+          OR: [
+            { conditionId: { equals: sanitizedId, mode: 'insensitive' } },
+            { condition: { equals: sanitizedId, mode: 'insensitive' } },
+          ],
+          status: 'published',
+        },
+      });
+
+      if (!content) {
+        res.status(404).json({
+          error: 'Content not found',
+          message: `No published medical content found for condition: ${sanitizedId}`,
+          conditionId: sanitizedId,
+        });
+        return;
+      }
+
+      res.json(content);
+    } catch (error) {
+      console.error('[Content API] Error fetching condition:', {
+        conditionId: req.params.conditionId,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      res.status(500).json({
+        error: 'Internal server error',
+        message: 'Failed to fetch medical content. Please try again later.',
+      });
+    }
+  }
+);
+
+// Alias route for simpler frontend access
+router.get(
+  '/:conditionId',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const { conditionId } = req.params;
+
+      if (!conditionId || typeof conditionId !== 'string' || conditionId.trim() === '') {
+        res.status(400).json({
+          error: 'Invalid request',
+          message: 'conditionId parameter is required and must be a valid string',
+        });
+        return;
+      }
+
+      const sanitizedId = conditionId.trim().replace(/[<>"'`;]/g, '');
+
+      const content = await prisma.medicalContent.findFirst({
+        where: {
+          OR: [
+            { conditionId: { equals: sanitizedId, mode: 'insensitive' } },
+            { condition: { equals: sanitizedId, mode: 'insensitive' } },
+          ],
+          status: 'published',
+        },
+      });
+
+      if (!content) {
+        res.status(404).json({
+          error: 'Content not found',
+          message: `No published medical content found for condition: ${sanitizedId}`,
+          conditionId: sanitizedId,
+        });
+        return;
+      }
+
+      res.json(content);
+    } catch (error) {
+      console.error('[Content API] Error fetching condition:', {
+        conditionId: req.params.conditionId,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      res.status(500).json({
+        error: 'Internal server error',
+        message: 'Failed to fetch medical content. Please try again later.',
+      });
+    }
+  }
+);
+
+// Content Search Endpoint
+router.get('/search', async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { q, system, limit = 30 } = req.query;
+
+    if (!q) {
+      res.status(400).json({ error: 'Query parameter "q" is required' });
+      return;
+    }
+
+    const query = String(q);
+
+    type WhereClause = {
+      status: string;
+      OR: Array<{
+        condition?: { contains: string; mode: 'insensitive' };
+        overview?: { contains: string; mode: 'insensitive' };
+      }>;
+      AND?: Array<{
+        OR: Array<{
+          system?: string;
+          relatedSystems?: { has: string };
+        }>;
+      }>;
+    };
+
+    const where: WhereClause = {
+      status: 'published',
+      OR: [
+        { condition: { contains: query, mode: 'insensitive' } },
+        { overview: { contains: query, mode: 'insensitive' } },
+      ],
+    };
+
+    if (system) {
+      where.AND = [
+        {
+          OR: [{ system: String(system) }, { relatedSystems: { has: String(system) } }],
+        },
+      ];
+    }
+
+    const results = await prisma.medicalContent.findMany({
+      where,
+      take: Number(limit),
+      select: {
+        conditionId: true,
+        condition: true,
+        system: true,
+        subcategory: true,
+        overview: true,
+      },
+      orderBy: { condition: 'asc' },
+    });
+
+    res.json({ results, count: results.length });
+  } catch (error) {
+    console.error('Error searching content:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/routes/drills.ts
+++ b/routes/drills.ts
@@ -1,0 +1,253 @@
+/**
+ * Drills Routes (Express – local dev parity with CF /api/drills/*)
+ *
+ * GET  /api/drills/lab-cases – Lab cases for Mini Lab drill
+ * POST /api/drills/lab-cases – getDiagnoses for autocomplete
+ */
+
+import { Router, Request, Response } from 'express';
+import { prisma } from '../lib/prisma';
+import { requireAuth, AuthenticatedRequest } from '../lib/middleware/clerkAuth';
+
+const router = Router();
+
+interface LabValue {
+  name: string;
+  value: string;
+  unit: string;
+  referenceRange: string;
+  isAbnormal: boolean;
+  isCritical?: boolean;
+  abnormalDirection?: 'high' | 'low';
+}
+
+interface LabPanel {
+  name: string;
+  values: LabValue[];
+}
+
+interface TransformedLabCase {
+  id: string;
+  clinicalContext: string;
+  patientAge?: number;
+  patientSex?: string;
+  panels: LabPanel[];
+  correctDiagnosis: string;
+  keyFindings: string[];
+  explanation: string;
+  category: string;
+}
+
+function parseLabValue(
+  valueStr: string,
+  defaultUnit: string,
+  defaultRange: string
+): {
+  value: string;
+  unit: string;
+  referenceRange: string;
+  isAbnormal: boolean;
+  isCritical?: boolean;
+  abnormalDirection?: 'high' | 'low';
+} | null {
+  if (!valueStr || typeof valueStr !== 'string') return null;
+  const numMatch = valueStr.match(/[\d.]+/);
+  if (!numMatch) return null;
+  const value = numMatch[0];
+  const lowerStr = valueStr.toLowerCase();
+  const isDecreased = lowerStr.includes('decreased') || lowerStr.includes('low');
+  const isIncreased =
+    lowerStr.includes('increased') || lowerStr.includes('high') || lowerStr.includes('elevated');
+  const isCritical = lowerStr.includes('critical') || lowerStr.includes('danger');
+  const isAbnormal = isDecreased || isIncreased;
+  return {
+    value,
+    unit: defaultUnit,
+    referenceRange: defaultRange,
+    isAbnormal,
+    isCritical: isCritical || undefined,
+    abnormalDirection: isDecreased ? 'low' : isIncreased ? 'high' : undefined,
+  };
+}
+
+const PANEL_CONFIGS: {
+  key: string;
+  name: string;
+  mappings: { key: string; name: string; unit: string; range: string }[];
+}[] = [
+  {
+    key: 'completeBloodCount',
+    name: 'Complete Blood Count',
+    mappings: [
+      { key: 'hemoglobin', name: 'Hemoglobin', unit: 'g/dL', range: '12.0-16.0' },
+      { key: 'hematocrit', name: 'Hematocrit', unit: '%', range: '36-48' },
+      { key: 'whiteBloodCellCount', name: 'WBC', unit: 'k/μL', range: '4.5-11.0' },
+      { key: 'plateletCount', name: 'Platelets', unit: 'k/μL', range: '150-400' },
+    ],
+  },
+  {
+    key: 'basicMetabolicPanel',
+    name: 'Basic Metabolic Panel',
+    mappings: [
+      { key: 'glucose', name: 'Glucose', unit: 'mg/dL', range: '70-100' },
+      { key: 'sodium', name: 'Sodium', unit: 'mEq/L', range: '136-145' },
+      { key: 'potassium', name: 'Potassium', unit: 'mEq/L', range: '3.5-5.0' },
+      { key: 'creatinine', name: 'Creatinine', unit: 'mg/dL', range: '0.7-1.3' },
+    ],
+  },
+  {
+    key: 'metabolicPanel',
+    name: 'Basic Metabolic Panel',
+    mappings: [
+      { key: 'glucose', name: 'Glucose', unit: 'mg/dL', range: '70-100' },
+      { key: 'sodium', name: 'Sodium', unit: 'mEq/L', range: '136-145' },
+      { key: 'potassium', name: 'Potassium', unit: 'mEq/L', range: '3.5-5.0' },
+      { key: 'creatinine', name: 'Creatinine', unit: 'mg/dL', range: '0.7-1.3' },
+    ],
+  },
+];
+
+function transformLabCase(dbCase: {
+  id: string;
+  clinicalVignette: string;
+  correctDiagnosis: string;
+  labs: Record<string, unknown>;
+}): TransformedLabCase {
+  const labs = dbCase.labs || {};
+  const panels: LabPanel[] = [];
+  const keyFindings: string[] = [];
+
+  for (const panelConfig of PANEL_CONFIGS) {
+    const panelData = labs[panelConfig.key] as Record<string, string> | undefined;
+    if (!panelData) continue;
+    const labPanel: LabPanel = { name: panelConfig.name, values: [] };
+    for (const m of panelConfig.mappings) {
+      const val = panelData[m.key];
+      if (!val) continue;
+      const parsed = parseLabValue(val, m.unit, m.range);
+      if (parsed) {
+        labPanel.values.push({ name: m.name, ...parsed });
+        if (parsed.isAbnormal && parsed.abnormalDirection) {
+          keyFindings.push(
+            `${m.name}: ${parsed.value} ${parsed.unit} (${parsed.abnormalDirection})`
+          );
+        }
+      }
+    }
+    if (labPanel.values.length > 0) panels.push(labPanel);
+  }
+
+  const diagnosis = dbCase.correctDiagnosis.toLowerCase();
+  let category = 'random';
+  if (
+    diagnosis.includes('anemia') ||
+    diagnosis.includes('hematology') ||
+    diagnosis.includes('hemolytic')
+  )
+    category = 'hematology';
+  else if (
+    diagnosis.includes('diabetic') ||
+    diagnosis.includes('dka') ||
+    diagnosis.includes('acidosis')
+  )
+    category = 'metabolic';
+  else if (
+    diagnosis.includes('thyroid') ||
+    diagnosis.includes('addison') ||
+    diagnosis.includes('siadh')
+  )
+    category = 'endocrine';
+  else if (
+    diagnosis.includes('renal') ||
+    diagnosis.includes('kidney') ||
+    diagnosis.includes('nephrotic')
+  )
+    category = 'renal';
+  else if (
+    diagnosis.includes('hepat') ||
+    diagnosis.includes('liver') ||
+    diagnosis.includes('cirrhosis')
+  )
+    category = 'hepatic';
+  else if (
+    diagnosis.includes('cardiac') ||
+    diagnosis.includes('heart') ||
+    diagnosis.includes('infarction')
+  )
+    category = 'cardiac';
+
+  const explanation = `The lab findings are consistent with ${dbCase.correctDiagnosis}.`;
+
+  return {
+    id: dbCase.id,
+    clinicalContext: dbCase.clinicalVignette,
+    panels,
+    correctDiagnosis: dbCase.correctDiagnosis,
+    keyFindings: keyFindings.slice(0, 5),
+    explanation,
+    category,
+  };
+}
+
+router.get('/lab-cases', requireAuth, async (req: Request, res: Response): Promise<void> => {
+  try {
+    if (!process.env.DATABASE_URL) {
+      res.status(503).json({ success: false, error: 'Database not configured' });
+      return;
+    }
+    const category = (req.query.category as string) || undefined;
+    const limit = Math.min(Number(req.query.limit) || 20, 100);
+    const shuffle = req.query.shuffle !== 'false';
+
+    const dbCases = await prisma.labCase.findMany({ take: limit * 2 });
+    let transformed = dbCases
+      .map((c) =>
+        transformLabCase({
+          id: c.id,
+          clinicalVignette: c.clinicalVignette,
+          correctDiagnosis: c.correctDiagnosis,
+          labs: (c.labs ?? {}) as Record<string, unknown>,
+        })
+      )
+      .filter((c) => c.panels.length > 0);
+
+    if (category && category !== 'random') {
+      transformed = transformed.filter((c) => c.category === category);
+    }
+    if (shuffle) {
+      transformed = transformed.sort(() => Math.random() - 0.5);
+    }
+    transformed = transformed.slice(0, limit);
+
+    res.json({ success: true, cases: transformed, total: transformed.length });
+  } catch (error) {
+    console.error('Error fetching lab cases:', error);
+    res.status(500).json({ success: false, error: 'Failed to fetch lab cases' });
+  }
+});
+
+router.post(
+  '/lab-cases',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      if (!process.env.DATABASE_URL) {
+        res.status(503).json({ success: false, error: 'Database not configured' });
+        return;
+      }
+      const action = req.body?.action;
+      if (action !== 'getDiagnoses') {
+        res.status(400).json({ success: false, error: 'Invalid action' });
+        return;
+      }
+      const cases = await prisma.labCase.findMany({ select: { correctDiagnosis: true } });
+      const diagnoses = [...new Set(cases.map((c) => c.correctDiagnosis))].sort();
+      res.json({ success: true, diagnoses });
+    } catch (error) {
+      console.error('Error in lab-cases POST:', error);
+      res.status(500).json({ success: false, error: 'Request failed' });
+    }
+  }
+);
+
+export default router;

--- a/routes/drugs.ts
+++ b/routes/drugs.ts
@@ -1,0 +1,106 @@
+/**
+ * ============================================================================
+ * ⚠️  LEGACY ROUTE - LOCAL DEVELOPMENT ONLY ⚠️ // pragma: allowlist secret
+ * ============================================================================
+ *
+ * This Express route is for LOCAL DEVELOPMENT and TESTING only. // pragma: allowlist secret
+ *
+ * PRODUCTION uses Cloudflare Pages Functions in /functions/api/
+ *
+ * See: CLOUDFLARE_FUNCTIONS_GUIDE.md for production deployment info.
+ * ============================================================================
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { prisma } from '../lib/prisma';
+
+const router = Router();
+
+/**
+ * GET /api/drugs or /api/drugs/all
+ * Get all drugs or filtered by limit (same handler for CF parity)
+ */
+const getAllDrugs = async (req: Request, res: Response) => {
+  try {
+    const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : undefined;
+
+    const drugs = await prisma.drug.findMany({
+      take: limit,
+      orderBy: { genericName: 'asc' },
+    });
+
+    res.setHeader('Cache-Control', 'public, max-age=60');
+    res.json(drugs);
+  } catch (error) {
+    console.error('Error fetching drugs:', error);
+    res.status(500).json({
+      error: 'Failed to fetch drugs from database',
+      details: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+};
+
+router.get('/', getAllDrugs);
+router.get('/all', getAllDrugs);
+
+/**
+ * GET /api/drugs/random
+ * Get random drugs for drill sessions
+ */
+router.get('/random', async (req, res) => {
+  try {
+    const count = parseInt(req.query.count as string, 10) || 10;
+
+    // Get random drugs using SQL
+    const drugs = await prisma.$queryRaw`
+      SELECT * FROM "Drug"
+      ORDER BY RANDOM()
+      LIMIT ${count}
+    `;
+
+    res.json(drugs);
+  } catch (error) {
+    console.error('Error fetching random drugs:', error);
+    res.status(500).json({
+      error: 'Failed to fetch random drugs',
+      details: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+/**
+ * GET /api/drugs/search
+ * Search drugs by name or class
+ */
+router.get('/search', async (req, res): Promise<void> => {
+  try {
+    const query = (req.query.q as string) || '';
+
+    if (!query) {
+      res.status(400).json({ error: 'Search query is required' });
+      return;
+    }
+
+    const drugs = await prisma.drug.findMany({
+      where: {
+        OR: [
+          { genericName: { contains: query, mode: 'insensitive' } },
+          { brandName: { contains: query, mode: 'insensitive' } },
+          { drugClass: { hasSome: [query] } },
+        ],
+      },
+      take: 50,
+      orderBy: { genericName: 'asc' },
+    });
+
+    res.json(drugs);
+  } catch (error) {
+    console.error('Error searching drugs:', error);
+    res.status(500).json({
+      error: 'Failed to search drugs',
+      details: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+export default router;

--- a/routes/games.ts
+++ b/routes/games.ts
@@ -1,0 +1,250 @@
+/**
+ * Games Routes
+ *
+ * Handles all game-related API endpoints (wordle, grand rounds).
+ * Extracted from server.ts for modularity.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { Router, Response } from 'express';
+import { prisma } from '../lib/prisma';
+import { requireAuth, AuthenticatedRequest } from '../lib/middleware/clerkAuth';
+import { validateRequired } from '../lib/middleware/validation';
+import {
+  getDailyWordForUser,
+  submitWordleGuess,
+  WordleServiceError,
+} from '../services/core/wordleService';
+import { normalizeOptionsToArray } from '../lib/utils/questionDataNormalizer';
+import crypto from 'crypto';
+
+const router = Router();
+
+// ============================================================================
+// Medical Wordle
+// ============================================================================
+
+router.get(
+  '/wordle/daily',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const payload = await getDailyWordForUser(req.auth!.userId);
+      res.json(payload);
+    } catch (error) {
+      if (error instanceof WordleServiceError) {
+        res.status(400).json({ error: error.message });
+        return;
+      }
+      console.error('Error fetching Wordle daily word:', error);
+      res.status(500).json({ error: 'Failed to load Wordle challenge' });
+    }
+  }
+);
+
+router.post(
+  '/wordle/guess',
+  requireAuth,
+  validateRequired(['guess']),
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const { guess } = req.body;
+      const payload = await submitWordleGuess(req.auth!.userId, guess);
+      res.json(payload);
+    } catch (error) {
+      if (error instanceof WordleServiceError) {
+        res.status(400).json({ error: error.message });
+        return;
+      }
+      console.error('Error submitting Wordle guess:', error);
+      res.status(500).json({ error: 'Failed to submit Wordle guess' });
+    }
+  }
+);
+
+// ============================================================================
+// Grand Rounds Daily Challenge
+// ============================================================================
+
+router.get(
+  '/grand-rounds/today',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      if (!process.env.DATABASE_URL) {
+        res.status(503).json({ error: 'Database not configured' });
+        return;
+      }
+
+      const userId = req.auth!.userId;
+
+      const user = await prisma.user.findUnique({ where: { clerkId: userId } });
+      if (!user) {
+        res.status(404).json({ error: 'User not found' });
+        return;
+      }
+
+      const { getOrCreateDailyChallenge, getUserAttemptForChallenge } =
+        await import('../lib/services/grandRoundsService');
+
+      const challenge = await getOrCreateDailyChallenge();
+      const existingAttempt = await getUserAttemptForChallenge(user.id, challenge.id);
+
+      if (existingAttempt) {
+        const { calculatePercentile, getRankingForChallenge } =
+          await import('../lib/services/grandRoundsService');
+
+        const percentile = await calculatePercentile(challenge.id, existingAttempt.score);
+        const ranking = await getRankingForChallenge(
+          challenge.id,
+          existingAttempt.score,
+          existingAttempt.timeSpentMs
+        );
+        const totalQuestions = challenge.questionIds.length;
+        const correctCount = Math.floor(existingAttempt.score / 20);
+
+        res.json({
+          status: 'completed',
+          stats: {
+            score: existingAttempt.score,
+            correctCount,
+            totalQuestions,
+            timeSpentMs: existingAttempt.timeSpentMs,
+            percentile,
+            ranking,
+          },
+        });
+        return;
+      }
+
+      const questions = await prisma.question.findMany({
+        where: {
+          id: { in: challenge.questionIds },
+        },
+        select: {
+          id: true,
+          vignette: true,
+          question: true,
+          options: true,
+          system: true,
+          difficulty: true,
+        },
+      });
+
+      // Normalize options for each question
+      const normalizedQuestions = questions.map((q) => ({
+        ...q,
+        options: normalizeOptionsToArray(q.options),
+      }));
+
+      res.json({
+        status: 'active',
+        challengeId: challenge.id,
+        questions: normalizedQuestions,
+      });
+    } catch (error) {
+      console.error('Error fetching Grand Rounds challenge:', error);
+      res.status(500).json({ error: 'Failed to fetch challenge' });
+    }
+  }
+);
+
+router.post(
+  '/grand-rounds/submit',
+  requireAuth,
+  validateRequired(['challengeId', 'answers', 'timeSpentMs']),
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      if (!process.env.DATABASE_URL) {
+        res.status(503).json({ error: 'Database not configured' });
+        return;
+      }
+
+      const userId = req.auth!.userId;
+      const { challengeId, answers, timeSpentMs } = req.body;
+
+      if (typeof answers !== 'object' || Array.isArray(answers)) {
+        res.status(400).json({ error: 'Invalid answers format' });
+        return;
+      }
+
+      const user = await prisma.user.findUnique({ where: { clerkId: userId } });
+      if (!user) {
+        res.status(404).json({ error: 'User not found' });
+        return;
+      }
+
+      const { getUserAttemptForChallenge, calculatePercentile, getRankingForChallenge } =
+        await import('../lib/services/grandRoundsService');
+
+      const existingAttempt = await getUserAttemptForChallenge(user.id, challengeId);
+      if (existingAttempt) {
+        res.status(400).json({ error: 'Challenge already completed' });
+        return;
+      }
+
+      const challenge = await prisma.grandRoundsChallenge.findUnique({
+        where: { id: challengeId },
+      });
+
+      if (!challenge) {
+        res.status(404).json({ error: 'Challenge not found' });
+        return;
+      }
+
+      const questions = await prisma.question.findMany({
+        where: {
+          id: { in: challenge.questionIds },
+        },
+        select: {
+          id: true,
+          correctAnswer: true,
+        },
+      });
+
+      let correctCount = 0;
+      const POINTS_PER_CORRECT = 20;
+
+      for (const question of questions) {
+        const userAnswer = answers[question.id];
+        if (userAnswer === question.correctAnswer) {
+          correctCount++;
+        }
+      }
+
+      const rawScore = correctCount * POINTS_PER_CORRECT;
+      const timeInMinutes = timeSpentMs / 60000;
+      const speedBonus = correctCount > 0 ? Math.max(0, Math.min(20, 20 - timeInMinutes)) : 0;
+      const finalScore = Math.round(rawScore + speedBonus);
+
+      await prisma.grandRoundsAttempt.create({
+        data: {
+          id: uuidv4(),
+          userId: user.id,
+          challengeId,
+          score: finalScore,
+          correctCount,
+          timeSpentMs,
+        },
+      });
+
+      const percentile = await calculatePercentile(challengeId, finalScore);
+      const ranking = await getRankingForChallenge(challengeId, finalScore, timeSpentMs);
+
+      res.json({
+        success: true,
+        score: finalScore,
+        correctCount,
+        totalQuestions: questions.length,
+        speedBonus: Math.round(speedBonus),
+        percentile,
+        ranking,
+      });
+    } catch (error) {
+      console.error('Error submitting Grand Rounds:', error);
+      res.status(500).json({ error: 'Failed to submit challenge' });
+    }
+  }
+);
+
+export default router;

--- a/routes/index.ts
+++ b/routes/index.ts
@@ -1,0 +1,103 @@
+/**
+ * ============================================================================
+ * ⚠️  LEGACY ROUTES - LOCAL DEVELOPMENT ONLY ⚠️ // pragma: allowlist secret
+ * ============================================================================
+ *
+ * These Express routes are for LOCAL DEVELOPMENT and TESTING only. // pragma: allowlist secret
+ *
+ * PRODUCTION uses Cloudflare Pages Functions in /functions/api/
+ *
+ * These routes may have auth drift or missing features compared to
+ * the Cloudflare Functions equivalents. Always prefer implementing
+ * new features in /functions/api/ directly.
+ *
+ * See: CLOUDFLARE_FUNCTIONS_GUIDE.md for production deployment info.
+ * ============================================================================
+ */
+
+import { Express } from 'express';
+
+// Import all route modules
+import conditionsRouter from './conditions';
+import contentRouter from './content';
+import referenceRouter from './reference';
+import labsRouter from './labs';
+import drugsRouter from './drugs';
+import buzzwordsRouter from './buzzwords';
+import gamesRouter from './games';
+import analyticsRouter from './analytics';
+import syncRouter from './sync';
+import questionsRouter from './questions';
+import pearlsRouter from './pearls';
+import osceRouter from './osce';
+import aiRouter from './ai';
+import usersRouter from './users';
+import recommendationsRouter from './recommendations';
+
+import adaptiveRouter from './adaptive';
+import drillsRouter from './drills';
+import auditRouter from './audit';
+
+/**
+ * Register all API routes with the Express application.
+ * Routes are mounted under their respective base paths.
+ *
+ * NOTE: Routes marked DORMANT are not actively used by the frontend.
+ */
+export function registerRoutes(app: Express): void {
+  // ─── Core data routes ─────────────────────────────────────────────────
+  // [PORTED] → functions/api/conditions/index.ts
+  app.use('/api/conditions', conditionsRouter);
+  // [PORTED] → functions/api/content/ (all, [conditionId], search, systems, library, curated-passages, textbook-retrieve, context-widgets)
+  app.use('/api/content', contentRouter);
+  // [PORTED] → functions/api/reference/ (anatomy, differentials, labs, guidelines, findings, imaging, physiology, special-tests, treatments, vitals, procedures, scoring)
+  app.use('/api/reference', referenceRouter);
+
+  // ─── Lab and study material routes ────────────────────────────────────
+  // [PORTED] → functions/api/labs/ (tests, cases, cases/random)
+  app.use('/api/labs', labsRouter);
+  // [PORTED] → functions/api/drills/ (lab-cases, contrastive, pharm, smart-review, antibiotics, fluids, code-blue, confusion-queue)
+  app.use('/api/drills', drillsRouter);
+  // [PORTED] → functions/api/drugs/index.ts
+  app.use('/api/drugs', drugsRouter);
+  // [PORTED] → functions/api/buzzwords/index.ts
+  app.use('/api/buzzwords', buzzwordsRouter);
+
+  // [DORMANT] Game routes - MedicalWordle not used in App.tsx
+  app.use('/api/games', gamesRouter);
+
+  // ─── New modules ──────────────────────────────────────────────────────
+  // [PORTED] → functions/api/analytics/ (reactions, weakness, confusion-pairs, performance-deltas, soap-note, blueprint-coverage, calibration, error-patterns, learner-profile, knowledge-graph, etc.)
+  app.use('/api/analytics', analyticsRouter);
+  // [PORTED] → functions/api/sync.ts (GET + POST with 3-way merge)
+  app.use('/api/sync', syncRouter);
+  // [PORTED] → functions/api/questions/ (32+ handlers: fetch, batch, no-repeat, flag, seeds, generate, pool, attempt, session, custom-session, staging, etc.)
+  app.use('/api/questions', questionsRouter);
+
+  // [DORMANT] Clinical pearls - not called by frontend
+  app.use('/api/pearls', pearlsRouter);
+  // [PORTED] → functions/api/osce/ (cases/random, session, chat, complete, stats, analytics, live-engine, state-machine, analysis)
+  app.use('/api/osce', osceRouter);
+  // [PORTED] → functions/api/ai/ (chat, learning, mnemonics, models, sessions, tutor, vision)
+  app.use('', aiRouter);
+
+  // [PARTIAL] → functions/api/achievements/ (record, unlock, [userId]); functions/api/user/ (session, analytics, daily-performance). Some perf endpoints may still need Edge equivalents.
+  app.use('/api', usersRouter);
+
+  // [DORMANT] Adaptive learning - not called by frontend
+  app.use('/api/adaptive', adaptiveRouter);
+  // [PORTED] → functions/api/recommendations/index.ts
+  app.use('/api/recommendations', recommendationsRouter);
+
+  // [DORMANT] Admin audit routes
+  app.use('/api/audit', auditRouter);
+
+  console.log('✓ Route modules registered:');
+  console.log('  - /api/conditions, /api/content, /api/reference');
+  console.log('  - /api/labs, /api/drills, /api/drugs, /api/buzzwords');
+  console.log('  - /api/analytics, /api/sync');
+  console.log('  - /api/questions, /api/osce');
+  console.log('  - /api/performance, /api/achievements');
+  console.log('  - /api/audit (admin)');
+  console.log('  [DORMANT]: /api/games, /api/pearls, /api/adaptive, /api/recommendations');
+}

--- a/routes/labs.ts
+++ b/routes/labs.ts
@@ -1,0 +1,55 @@
+/**
+ * Labs Routes
+ *
+ * Handles all lab-related API endpoints (lab tests, lab cases).
+ * Extracted from server.ts for modularity.
+ */
+
+import { Router, Request, Response } from 'express';
+import { prisma } from '../lib/prisma';
+
+const router = Router();
+
+// Lab Tests
+router.get('/tests', async (req: Request, res: Response) => {
+  try {
+    const tests = await prisma.labTest.findMany({
+      orderBy: { name: 'asc' },
+    });
+    res.json(tests);
+  } catch (error) {
+    console.error('Error fetching lab tests:', error);
+    res.status(500).json({ error: 'Failed to fetch lab tests' });
+  }
+});
+
+// Lab Cases
+router.get('/cases', async (req: Request, res: Response) => {
+  try {
+    const cases = await prisma.labCase.findMany();
+    res.json(cases);
+  } catch (error) {
+    console.error('Error fetching lab cases:', error);
+    res.status(500).json({ error: 'Failed to fetch lab cases' });
+  }
+});
+
+// Random Lab Cases
+router.get('/cases/random', async (req: Request, res: Response) => {
+  try {
+    const count = parseInt(req.query.count as string) || 1;
+
+    const cases = await prisma.$queryRaw`
+      SELECT * FROM "LabCase"
+      ORDER BY RANDOM()
+      LIMIT ${count}
+    `;
+
+    res.json(cases);
+  } catch (error) {
+    console.error('Error fetching random lab cases:', error);
+    res.status(500).json({ error: 'Failed to fetch random lab cases' });
+  }
+});
+
+export default router;

--- a/routes/osce.ts
+++ b/routes/osce.ts
@@ -1,0 +1,262 @@
+/**
+ * OSCE Routes
+ *
+ * Handles all Patient Encounter / OSCE related API endpoints.
+ * Extracted from server.ts for modularity.
+ * Supports both wrapped body ({ body: { ... } }) and flat body for local dev parity with Cloudflare.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { Router, Response } from 'express';
+import { prisma } from '../lib/prisma';
+import { requireAuth, AuthenticatedRequest } from '../lib/middleware/clerkAuth';
+
+const router = Router();
+
+function getBody<T>(req: AuthenticatedRequest): T {
+  const b = req.body as Record<string, unknown>;
+  return (b?.body ?? b) as T;
+}
+
+// Get a random patient encounter case
+router.get(
+  '/cases/random',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      if (!req.auth?.userId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      if (!process.env.DATABASE_URL) {
+        res.status(503).json({ error: 'Database not configured' });
+        return;
+      }
+
+      const count = await prisma.patientEncounterCase.count();
+      if (count === 0) {
+        res.status(404).json({ error: 'No cases found' });
+        return;
+      }
+
+      // Efficient random selection using skip
+      const skip = Math.floor(Math.random() * count);
+      const randomCase = await prisma.patientEncounterCase.findFirst({
+        skip: skip,
+      });
+
+      res.json(randomCase);
+      return;
+    } catch (error) {
+      console.error('Error fetching random case:', error);
+      res.status(500).json({ error: 'Internal server error' });
+      return;
+    }
+  }
+);
+
+// Create or get active session
+router.post(
+  '/session',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const userId = req.auth?.userId;
+      if (!userId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      const body = getBody<{ caseId: string }>(req);
+      const caseId = body?.caseId;
+
+      if (!process.env.DATABASE_URL) {
+        res.json({ success: true, sessionId: 'mock-session-id' });
+        return;
+      }
+
+      const user = await prisma.user.findUnique({ where: { clerkId: userId } });
+
+      if (!user) {
+        res.status(404).json({ error: 'User not found' });
+        return;
+      }
+
+      // Check for existing active session for this case
+      const existingSession = await prisma.patientEncounterSession.findFirst({
+        where: {
+          userId: user.id,
+          caseId: caseId,
+          status: 'active',
+        },
+      });
+
+      if (existingSession) {
+        res.json({ success: true, session: existingSession });
+        return;
+      }
+
+      const now = new Date();
+      // Create new session (updatedAt required by schema)
+      const session = await prisma.patientEncounterSession.create({
+        data: {
+          id: uuidv4(),
+          userId: user.id,
+          caseId,
+          messages: [],
+          status: 'active',
+          updatedAt: now,
+        },
+      });
+
+      res.json({ success: true, session });
+      return;
+    } catch (error) {
+      console.error('Error creating OSCE session:', error);
+      res.status(500).json({ error: 'Failed to create session' });
+      return;
+    }
+  }
+);
+
+// Get active session details (ownership enforced)
+router.get(
+  '/session/:sessionId',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const userId = req.auth?.userId;
+      if (!userId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      const { sessionId } = req.params;
+
+      if (!process.env.DATABASE_URL) {
+        res.json({ success: true, session: null });
+        return;
+      }
+
+      const user = await prisma.user.findUnique({ where: { clerkId: userId } });
+      if (!user) {
+        res.status(404).json({ error: 'User not found' });
+        return;
+      }
+
+      const session = await prisma.patientEncounterSession.findUnique({
+        where: { id: sessionId },
+      });
+
+      if (!session || session.userId !== user.id) {
+        res.status(404).json({ error: 'Session not found' });
+        return;
+      }
+
+      res.json({ success: true, session });
+      return;
+    } catch (error) {
+      console.error('Error fetching OSCE session:', error);
+      res.status(500).json({ error: 'Failed to fetch session' });
+      return;
+    }
+  }
+);
+
+// Append chat message (ownership enforced)
+router.post(
+  '/chat',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const userId = req.auth?.userId;
+      if (!userId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      const body = getBody<{ sessionId: string; messages: unknown[] }>(req);
+      const { sessionId, messages } = body ?? {};
+
+      if (!process.env.DATABASE_URL) {
+        res.json({ success: true });
+        return;
+      }
+
+      const user = await prisma.user.findUnique({ where: { clerkId: userId } });
+      if (!user) {
+        res.status(404).json({ error: 'User not found' });
+        return;
+      }
+
+      const updated = await prisma.patientEncounterSession.updateMany({
+        where: { id: sessionId, userId: user.id },
+        data: {
+          messages: messages ?? [],
+          updatedAt: new Date(),
+        },
+      });
+
+      if (updated.count === 0) {
+        res.status(404).json({ error: 'Session not found' });
+        return;
+      }
+
+      res.json({ success: true });
+      return;
+    } catch (error) {
+      console.error('Error saving OSCE chat:', error);
+      res.status(500).json({ error: 'Failed to save chat' });
+      return;
+    }
+  }
+);
+
+// Complete session (ownership enforced)
+router.post(
+  '/complete',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const userId = req.auth?.userId;
+      if (!userId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      const body = getBody<{ sessionId: string; diagnosis?: string; treatmentPlan?: string }>(req);
+      const { sessionId, diagnosis, treatmentPlan } = body ?? {};
+
+      if (!process.env.DATABASE_URL) {
+        res.json({ success: true });
+        return;
+      }
+
+      const user = await prisma.user.findUnique({ where: { clerkId: userId } });
+      if (!user) {
+        res.status(404).json({ error: 'User not found' });
+        return;
+      }
+
+      const updated = await prisma.patientEncounterSession.updateMany({
+        where: { id: sessionId, userId: user.id },
+        data: {
+          status: 'completed',
+          diagnosis,
+          treatmentPlan,
+          updatedAt: new Date(),
+        },
+      });
+
+      if (updated.count === 0) {
+        res.status(404).json({ error: 'Session not found' });
+        return;
+      }
+
+      res.json({ success: true });
+      return;
+    } catch (error) {
+      console.error('Error completing OSCE session:', error);
+      res.status(500).json({ error: 'Failed to complete session' });
+      return;
+    }
+  }
+);
+
+export default router;

--- a/routes/pearls.ts
+++ b/routes/pearls.ts
@@ -1,0 +1,170 @@
+/**
+ * Clinical Pearls Routes
+ *
+ * Handles all clinical pearl-related API endpoints.
+ * Extracted from server.ts for modularity.
+ */
+
+import { Router, Request, Response } from 'express';
+import { validateRequired } from '../lib/middleware/validation';
+
+const router = Router();
+
+// Extract clinical pearl from explanation
+router.post(
+  '/extract',
+  validateRequired(['questionId', 'explanation']),
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      if (!process.env.DATABASE_URL) {
+        res.status(503).json({ success: false, error: 'Database not configured' });
+        return;
+      }
+
+      const { createClinicalPearl } = await import('../services/domain/clinicalPearlService');
+      const { questionId, explanation, metadata } = req.body;
+      if (typeof questionId !== 'string') {
+        res.status(400).json({ success: false, error: 'questionId is required' });
+        return;
+      }
+      const pearl = await createClinicalPearl(questionId, explanation, metadata);
+
+      res.json({ success: true, pearl });
+    } catch (error) {
+      console.error('Failed to extract pearl:', error);
+      res.status(500).json({ success: false, error: 'Failed to extract pearl' });
+    }
+  }
+);
+
+// Get daily pearl
+router.get('/daily', async (req: Request, res: Response): Promise<void> => {
+  try {
+    if (!process.env.DATABASE_URL) {
+      res.json({ success: true, pearl: null });
+      return;
+    }
+
+    const { getDailyPearl } = await import('../services/domain/clinicalPearlService');
+    const userId = req.query.userId as string | undefined;
+    const pearl = await getDailyPearl(userId ?? '');
+
+    res.json({ success: true, pearl });
+  } catch (error) {
+    console.error('Failed to get daily pearl:', error);
+    res.status(500).json({ success: false, error: 'Failed to get daily pearl' });
+  }
+});
+
+// Get user's pearls (Review My Pearls)
+router.get('/user/:userId', async (req: Request, res: Response): Promise<void> => {
+  try {
+    if (!process.env.DATABASE_URL) {
+      res.json({ success: true, pearls: [] });
+      return;
+    }
+
+    const { getUserPearls } = await import('../services/domain/clinicalPearlService');
+    const userId = req.params.userId;
+    if (!userId) {
+      res.status(400).json({ success: false, error: 'userId is required' });
+      return;
+    }
+    const { limit = 20 } = req.query;
+    const pearls = await getUserPearls(userId, Number(limit));
+
+    res.json({ success: true, pearls });
+  } catch (error) {
+    console.error('Failed to get user pearls:', error);
+    res.status(500).json({ success: false, error: 'Failed to get user pearls' });
+  }
+});
+
+// Get user's favorite pearls
+router.get('/user/:userId/favorites', async (req: Request, res: Response): Promise<void> => {
+  try {
+    if (!process.env.DATABASE_URL) {
+      res.json({ success: true, pearls: [] });
+      return;
+    }
+
+    const { getUserFavoritePearls } = await import('../services/domain/clinicalPearlService');
+    const userId = req.params.userId;
+    if (!userId) {
+      res.status(400).json({ success: false, error: 'userId is required' });
+      return;
+    }
+    const pearls = await getUserFavoritePearls(userId);
+
+    res.json({ success: true, pearls });
+  } catch (error) {
+    console.error('Failed to get favorite pearls:', error);
+    res.status(500).json({ success: false, error: 'Failed to get favorite pearls' });
+  }
+});
+
+// Mark pearl as useful
+router.post(
+  '/:pearlId/useful',
+  validateRequired(['userId']),
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      if (!process.env.DATABASE_URL) {
+        res.status(503).json({ success: false, error: 'Database not configured' });
+        return;
+      }
+
+      const { markPearlUseful } = await import('../services/domain/clinicalPearlService');
+      const pearlId = req.params.pearlId;
+      const { userId, notes } = req.body;
+      if (!pearlId || typeof userId !== 'string') {
+        res.status(400).json({ success: false, error: 'pearlId and userId are required' });
+        return;
+      }
+      await markPearlUseful(userId, pearlId, notes);
+
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Failed to mark pearl as useful:', error);
+      res.status(500).json({ success: false, error: 'Failed to mark pearl as useful' });
+    }
+  }
+);
+
+// Search pearls
+router.post('/search', async (req: Request, res: Response): Promise<void> => {
+  try {
+    if (!process.env.DATABASE_URL) {
+      res.json({ success: true, pearls: [] });
+      return;
+    }
+
+    const { searchPearls } = await import('../services/domain/clinicalPearlService');
+    const pearls = await searchPearls(req.body);
+
+    res.json({ success: true, pearls });
+  } catch (error) {
+    console.error('Failed to search pearls:', error);
+    res.status(500).json({ success: false, error: 'Failed to search pearls' });
+  }
+});
+
+// Get pearl statistics
+router.get('/stats', async (req: Request, res: Response): Promise<void> => {
+  try {
+    if (!process.env.DATABASE_URL) {
+      res.json({ success: true, stats: {} });
+      return;
+    }
+
+    const { getPearlStats } = await import('../services/domain/clinicalPearlService');
+    const stats = await getPearlStats();
+
+    res.json({ success: true, stats });
+  } catch (error) {
+    console.error('Failed to get pearl stats:', error);
+    res.status(500).json({ success: false, error: 'Failed to get pearl stats' });
+  }
+});
+
+export default router;

--- a/routes/questions.ts
+++ b/routes/questions.ts
@@ -1,0 +1,838 @@
+/**
+ * Questions Routes
+ *
+ * Handles all question-related API endpoints including:
+ * - Fetching questions (bank, no-repeat, batch)
+ * - Flagging system
+ * - Question generation (AI)
+ * - Seed management
+ * - Drill submissions (grading)
+ *
+ * Extracted from server.ts for modularity.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { Router, Request, Response } from 'express';
+import { prisma } from '../lib/prisma';
+import { requireAuth, AuthenticatedRequest } from '../lib/middleware/clerkAuth';
+import { requireAdmin } from '../lib/middleware/adminAuth';
+import { validateRequired, validateEnum } from '../lib/middleware/validation';
+
+const router = Router();
+
+// ============================================================================
+// Question Fetching & Management
+// ============================================================================
+
+// Fetch questions from the database-first question bank
+router.get('/', async (req: Request, res: Response): Promise<void> => {
+  try {
+    if (!process.env.DATABASE_URL) {
+      res.status(503).json({ error: 'Database not configured' });
+      return;
+    }
+
+    const { system, difficulty } = req.query;
+    const limit = Number(req.query.limit) || 10;
+
+    const { getQuestionsWithFallback } = await import('../lib/services/questionBankService');
+
+    const result = await getQuestionsWithFallback({
+      system: system ? String(system) : undefined,
+      difficulty: difficulty ? String(difficulty) : undefined,
+      limit,
+    });
+
+    res.json({ success: true, ...result });
+  } catch (error) {
+    console.error('Error fetching questions:', error);
+    res.status(500).json({ error: 'Failed to fetch questions' });
+  }
+});
+
+// Fetch questions for a user (with no-repeat logic) - POST variant
+router.post('/fetch', async (req: Request, res: Response): Promise<void> => {
+  try {
+    if (!process.env.DATABASE_URL) {
+      res.status(503).json({ error: 'Database not configured' });
+      return;
+    }
+
+    const { system, difficulty, limit = 10 } = req.body || {};
+    const { getQuestionsWithFallback } = await import('../lib/services/questionBankService');
+
+    const result = await getQuestionsWithFallback({
+      system: system ? String(system) : undefined,
+      difficulty: difficulty ? String(difficulty) : undefined,
+      limit: Number(limit) || 10,
+    });
+
+    res.json({ success: true, ...result });
+  } catch (error) {
+    console.error('Error fetching questions:', error);
+    res.status(500).json({ error: 'Failed to fetch questions' });
+  }
+});
+
+// Question Query Route (Authenticated No-Repeat)
+router.post(
+  '/query',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const { system, difficulty, limit = 10 } = req.body;
+
+      if (!process.env.DATABASE_URL) {
+        res.json({ success: true, questions: [] });
+      }
+
+      const { getQuestionsWithNoRepeat } = await import('../services/core/noRepeatService');
+      const userId = req.auth!.userId;
+
+      const result = await getQuestionsWithNoRepeat(userId, { system, difficulty }, limit);
+
+      res.json({ success: true, questions: result.questions });
+    } catch (error) {
+      console.error('Error querying questions:', error);
+      res.status(500).json({ error: 'Failed to query questions' });
+    }
+  }
+);
+
+// Batch fetch questions by ID
+router.post(
+  '/batch',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const { ids } = req.body;
+
+      if (!ids || !Array.isArray(ids)) {
+        res.status(400).json({ error: 'Invalid request: ids array required' });
+        return;
+      }
+
+      if (process.env.DATABASE_URL) {
+        const questions = await prisma.preGeneratedQuestion.findMany({
+          where: {
+            id: { in: ids },
+          },
+        });
+
+        // Map to frontend Question format
+        const mappedQuestions = questions.map((q) => {
+          const qData = q.questionData as any;
+          return {
+            id: q.id,
+            question: qData?.question || qData?.text || 'Question text missing',
+            options: qData?.options || [],
+            correctAnswer: qData?.correctAnswer || '',
+            explanation: qData?.explanation || '',
+            system: q.system || undefined,
+            difficulty: q.difficulty || 'medium',
+            type: q.questionType || 'mcq',
+          };
+        });
+
+        res.json({ success: true, questions: mappedQuestions });
+      }
+
+      // Mock response if no DB
+      res.json({
+        success: true,
+        questions: ids.map((id) => ({
+          id,
+          question: `Mock Question for ID ${id}`,
+          options: ['Option A', 'Option B', 'Option C', 'Option D'],
+          correctAnswer: 'Option A',
+          explanation: 'This is a mock explanation because the database is not connected.',
+          system: 'General',
+          difficulty: 'medium',
+        })),
+      });
+    } catch (error) {
+      console.error('Error fetching batch questions:', error);
+      res.status(500).json({ error: 'Failed to fetch questions' });
+    }
+  }
+);
+
+// Get no-repeat questions (Task 109)
+router.post(
+  '/no-repeat',
+  validateRequired(['userId', 'filter']),
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      if (!process.env.DATABASE_URL) {
+        res.status(503).json({ success: false, error: 'Database not configured' });
+        return;
+      }
+
+      const { getQuestionsWithNoRepeat } = await import('../services/core/noRepeatService');
+      const { userId, filter, limit = 10 } = req.body;
+      const result = await getQuestionsWithNoRepeat(userId, filter, limit);
+
+      res.json({ success: true, ...result });
+    } catch (error) {
+      console.error('Failed to get questions:', error);
+      res.status(500).json({ success: false, error: 'Failed to get questions' });
+    }
+  }
+);
+
+// Record question seen
+router.post(
+  '/history',
+  validateRequired(['userId', 'questionId', 'metadata']),
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      if (!process.env.DATABASE_URL) {
+        res.status(503).json({ success: false, error: 'Database not configured' });
+        return;
+      }
+
+      const { recordQuestionSeen } = await import('../services/core/noRepeatService');
+      const { userId, questionId, metadata } = req.body;
+      await recordQuestionSeen(userId, questionId, metadata);
+
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Failed to record question history:', error);
+      res.status(500).json({ success: false, error: 'Failed to record question history' });
+    }
+  }
+);
+
+// Get golden repository statistics
+router.get('/repository/stats', async (req: Request, res: Response): Promise<void> => {
+  try {
+    if (!process.env.DATABASE_URL) {
+      res.json({ success: true, stats: { totalQuestions: 0 } });
+    }
+
+    const { getRepositoryStats } = await import('../services/core/noRepeatService');
+    const stats = await getRepositoryStats();
+
+    res.json({ success: true, stats });
+  } catch (error) {
+    console.error('Failed to get repository stats:', error);
+    res.status(500).json({ success: false, error: 'Failed to get repository stats' });
+  }
+});
+
+// Get question statistics (simple alias for repository stats)
+router.get('/stats', async (req: Request, res: Response): Promise<void> => {
+  try {
+    if (!process.env.DATABASE_URL) {
+      res.status(503).json({ error: 'Database not configured' });
+      return;
+    }
+
+    const { getRepositoryStats } = await import('../services/core/noRepeatService');
+    const stats = await getRepositoryStats();
+
+    res.json({
+      success: true,
+      stats,
+    });
+  } catch (error) {
+    console.error('Error getting stats:', error);
+    res.status(500).json({ error: 'Failed to get statistics' });
+  }
+});
+
+// ============================================================================
+// Flagging System
+// ============================================================================
+
+// Flag a question
+router.post(
+  '/flag',
+  validateRequired(['userId', 'questionId', 'flagType', 'description']),
+  validateEnum('flagType', ['typo', 'incorrect_answer', 'unclear', 'outdated', 'other']),
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const {
+        userId,
+        userEmail,
+        userFirstName,
+        questionId,
+        questionText,
+        correctAnswer,
+        topic,
+        system,
+        flagType,
+        description,
+        priority,
+      } = req.body;
+
+      if (!process.env.DATABASE_URL) {
+        res.status(503).json({
+          success: false,
+          error: 'Database not configured',
+        });
+        return;
+      }
+
+      const { sendAdminFlagNotification } = await import('../lib/services/notificationService');
+
+      // Create flag in database
+      const flag = await prisma.questionFlag.create({
+        data: {
+          id: uuidv4(),
+          userId,
+          userEmail: userEmail || null,
+          userFirstName: userFirstName || null,
+          questionId,
+          questionText: questionText || '',
+          correctAnswer: correctAnswer || null,
+          topic: topic || null,
+          system: system || null,
+          flagType,
+          description,
+          priority: priority || 'medium',
+          updatedAt: new Date(),
+        },
+      });
+
+      // Send notification to admin (if configured)
+      const adminEmail = process.env.ADMIN_EMAIL;
+      if (adminEmail) {
+        await sendAdminFlagNotification(adminEmail, {
+          id: flag.id,
+          questionId,
+          questionText: questionText || '',
+          flagType,
+          description,
+          userEmail,
+          userFirstName,
+        });
+      }
+
+      res.json({
+        success: true,
+        flagId: flag.id,
+        message: 'Question flagged successfully. We will review it soon!',
+      });
+    } catch (error) {
+      console.error('Failed to flag question:', error);
+      res.status(500).json({ success: false, error: 'Failed to flag question' });
+    }
+  }
+);
+
+// Resolve a flag (Admin-only)
+router.post(
+  '/flag/:flagId/resolve',
+  requireAdmin(),
+  validateRequired(['reviewedBy', 'resolutionNote']),
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { flagId } = req.params;
+      const { reviewedBy, resolutionNote } = req.body;
+
+      if (!process.env.DATABASE_URL) {
+        res.status(503).json({
+          success: false,
+          error: 'Database not configured',
+        });
+        return;
+      }
+
+      const { sendFlagResolvedNotification } = await import('../lib/services/notificationService');
+
+      // Update flag status
+      const flag = await prisma.questionFlag.update({
+        where: { id: flagId },
+        data: {
+          status: 'fixed',
+          reviewedBy,
+          reviewedAt: new Date(),
+          resolutionNote,
+        },
+      });
+
+      // Send notification to user
+      if (flag.userEmail) {
+        const notificationSent = await sendFlagResolvedNotification({
+          userEmail: flag.userEmail,
+          userFirstName: flag.userFirstName || undefined,
+          questionId: flag.questionId,
+          questionText: flag.questionText,
+          flagType: flag.flagType as any,
+          resolutionNote,
+        });
+
+        if (notificationSent) {
+          await prisma.questionFlag.update({
+            where: { id: flagId },
+            data: {
+              notificationSent: true,
+              notifiedAt: new Date(),
+            },
+          });
+        }
+      }
+
+      res.json({
+        success: true,
+        message: 'Flag resolved and user notified',
+      });
+    } catch (error) {
+      console.error('Failed to resolve flag:', error);
+      res.status(500).json({ success: false, error: 'Failed to resolve flag' });
+    }
+  }
+);
+
+// Get all flags (Admin-only)
+router.get('/flags', async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { status, priority } = req.query;
+
+    if (!process.env.DATABASE_URL) {
+      res.json({ success: true, flags: [] });
+    }
+
+    const flags = await prisma.questionFlag.findMany({
+      where: {
+        ...(status && { status: status as string }),
+        ...(priority && { priority: priority as string }),
+      },
+      orderBy: [{ priority: 'desc' }, { createdAt: 'desc' }],
+    });
+
+    res.json({ success: true, flags });
+  } catch (error) {
+    console.error('Failed to get flags:', error);
+    res.status(500).json({ success: false, error: 'Failed to get flags' });
+  }
+});
+
+// ============================================================================
+// Custom Study Session (parity with CF POST /api/questions/custom-session)
+// ============================================================================
+
+router.post(
+  '/custom-session',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      if (!process.env.DATABASE_URL) {
+        res.status(503).json({ error: 'Database not configured' });
+        return;
+      }
+
+      const body = req.body as { config?: Record<string, unknown>; count?: number };
+      const config = body?.config ?? {};
+      const requestedCount = Math.min(Number(body?.count) || 10, 50);
+
+      const systems = (config.systems as string[] | undefined) ?? [];
+      const subcategories = (config.subcategories as string[] | undefined) ?? [];
+      const conditions = (config.conditions as string[] | undefined) ?? [];
+      const focusAreas = (config.focusAreas as string[] | undefined) ?? [];
+      const difficulty = config.difficulty as string | undefined;
+
+      const whereConditions: Record<string, unknown>[] = [];
+
+      if (systems.length > 0) {
+        whereConditions.push({ system: { in: systems } });
+      }
+      if (subcategories.length > 0) {
+        whereConditions.push({ conditionId: { in: subcategories } });
+      }
+      if (conditions.length > 0) {
+        whereConditions.push({ conditionId: { in: conditions } });
+      }
+
+      const where = whereConditions.length > 0 ? { AND: whereConditions } : {};
+
+      const preGenRecords = await prisma.preGeneratedQuestion.findMany({
+        where,
+        take: requestedCount * 3,
+        orderBy: { generatedAt: 'asc' },
+      });
+
+      type PoolRow = (typeof preGenRecords)[0];
+      let filtered = preGenRecords as PoolRow[];
+      if (focusAreas.length > 0) {
+        filtered = preGenRecords.filter((r) => {
+          const data = (r.questionData as Record<string, unknown>) || {};
+          const fa = data.focusArea as string | undefined;
+          return !fa || focusAreas.includes(fa);
+        }) as PoolRow[];
+      }
+
+      if (difficulty && difficulty !== 'same') {
+        filtered = [...filtered].sort((a, b) => {
+          const dataA = (a.questionData as Record<string, unknown>) || {};
+          const dataB = (b.questionData as Record<string, unknown>) || {};
+          const aDiff = (typeof dataA.difficulty === 'number' ? dataA.difficulty : 50) as number;
+          const bDiff = (typeof dataB.difficulty === 'number' ? dataB.difficulty : 50) as number;
+          return difficulty === 'easier' ? aDiff - bDiff : bDiff - aDiff;
+        }) as PoolRow[];
+      }
+
+      const shuffled = [...filtered].sort(() => Math.random() - 0.5);
+      const selected = shuffled.slice(0, requestedCount);
+
+      const letters = ['A', 'B', 'C', 'D', 'E'];
+      const questions = selected.map((r) => {
+        const data = (r.questionData as Record<string, unknown>) || {};
+        const optsRaw = data.options ?? data.answers ?? data.choices;
+        const opts: string[] = Array.isArray(optsRaw) ? optsRaw : [];
+        let correct = (data.correctAnswer as string) || 'A';
+        if (typeof data.correctAnswerIndex === 'number') {
+          correct = letters[data.correctAnswerIndex] ?? 'A';
+        }
+        if (typeof data.correctIndex === 'number') {
+          correct = letters[data.correctIndex] ?? 'A';
+        }
+        const correctIndex = opts.findIndex(
+          (o) => o === correct || (typeof o === 'string' && o.includes(correct))
+        );
+        return {
+          id: r.id,
+          question: (data.question as string) || (data.text as string) || 'Question text missing',
+          options: opts,
+          correctAnswerIndex: correctIndex >= 0 ? correctIndex : 0,
+          rationale: (data.explanation as string) || (data.rationale as string) || '',
+          topic: (data.topic as string) || r.system || '',
+          system: r.system ?? undefined,
+          subcategory: (data.subcategory as string) ?? null,
+          conditionId: r.conditionId ?? undefined,
+          condition: (data.condition as string) || 'Unknown',
+          pearls: (data.pearls as string[]) || [],
+          focusArea: (data.focusArea as string) ?? undefined,
+          difficulty: (data.difficulty as number) ?? undefined,
+        };
+      });
+
+      const totalAvailable = await prisma.preGeneratedQuestion.count({ where });
+      let warning: string | undefined;
+      if (questions.length < requestedCount) {
+        warning = `Only ${questions.length} questions available matching your filters. Consider broadening your selection.`;
+      }
+
+      res.json({ questions, totalAvailable, warning });
+    } catch (error) {
+      console.error('Error fetching custom session questions:', error);
+      res.status(500).json({ error: 'Failed to fetch custom session questions' });
+    }
+  }
+);
+
+// ============================================================================
+// Question Pool (parity with CF /api/questions/pool)
+// ============================================================================
+
+router.get('/pool', async (req: Request, res: Response): Promise<void> => {
+  try {
+    if (!process.env.DATABASE_URL) {
+      res.status(503).json({ error: 'Database not configured' });
+      return;
+    }
+
+    const count = Math.min(Number(req.query.count) || 10, 50);
+    const system = (req.query.system as string) || undefined;
+    const difficulty = (req.query.difficulty as string) || undefined;
+
+    const where: Record<string, unknown> = {};
+    if (system) where.system = system;
+    if (difficulty) where.difficulty = difficulty;
+
+    // Try PreGeneratedQuestion first (seeded by seed:question-pool)
+    const preGenRecords = await prisma.preGeneratedQuestion.findMany({
+      where,
+      take: count * 3, // fetch extra for filtering
+      orderBy: { generatedAt: 'asc' },
+    });
+
+    const poolRemaining = await prisma.preGeneratedQuestion.count({ where });
+    const letters = ['A', 'B', 'C', 'D', 'E'];
+
+    const poolQuestions = preGenRecords.slice(0, count).map((r) => {
+      const data = (r.questionData as Record<string, unknown>) || {};
+      const optsRaw = data.options ?? data.answers ?? data.choices;
+      const opts: string[] = Array.isArray(optsRaw) ? optsRaw : [];
+      let correct = (data.correctAnswer as string) || 'A';
+      if (!correct && typeof data.correctAnswerIndex === 'number') {
+        correct = letters[data.correctAnswerIndex] ?? 'A';
+      }
+      if (!correct && typeof data.correctIndex === 'number') {
+        correct = letters[data.correctIndex] ?? 'A';
+      }
+      return {
+        id: r.id,
+        vignette: (data.vignette as string) || undefined,
+        question: (data.question as string) || 'Question text missing',
+        options: opts,
+        correctAnswer: correct,
+        explanation: (data.explanation as string) || '',
+        system: r.system || 'General',
+        difficulty: r.difficulty || 'medium',
+        tags: (data.tags as string[]) || [],
+        conditionId: r.conditionId ?? undefined,
+        source: 'pool',
+      };
+    });
+
+    // Fallback to Question table if PreGeneratedQuestion is empty
+    let questions = poolQuestions;
+    let available = poolRemaining;
+    if (questions.length === 0) {
+      const { getQuestionsWithFallback } = await import('../lib/services/questionBankService');
+      const { questions: fallbackQs, total } = await getQuestionsWithFallback({
+        system,
+        difficulty,
+        limit: count,
+      });
+      questions = fallbackQs.map((q) => {
+        const opts = q.options || [];
+        const correctIdx = opts.findIndex(
+          (o) =>
+            o === (q as { correctAnswer?: string }).correctAnswer ||
+            o.includes((q as { correctAnswer?: string }).correctAnswer ?? '')
+        );
+        const letter = (correctIdx >= 0 ? letters[correctIdx] : undefined) ?? 'A';
+        return {
+          id: q.id,
+          vignette: q.vignette || undefined,
+          question: q.question,
+          options: opts,
+          correctAnswer: letter,
+          explanation: q.explanation,
+          system: q.system || 'General',
+          difficulty: q.difficulty || 'medium',
+          tags: q.tags || [],
+          conditionId: (q as { conditionId?: string }).conditionId ?? undefined,
+          source: 'pool',
+        };
+      });
+      available = total;
+    }
+
+    const POOL_LOW_THRESHOLD = 20;
+    res.json({
+      questions,
+      poolStatus: {
+        available,
+        needsGeneration: available < POOL_LOW_THRESHOLD,
+        threshold: POOL_LOW_THRESHOLD,
+      },
+    });
+  } catch (error) {
+    console.error('Error fetching pool questions:', error);
+    res.status(500).json({ error: 'Failed to fetch questions from pool' });
+  }
+});
+
+// ============================================================================
+// Question Query & AI Generation
+// ============================================================================
+
+// Semantic cache & generation endpoint
+router.post(
+  '/generate',
+  validateRequired(['queryText', 'questionType']),
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { queryText, questionType, system, difficulty } = req.body;
+
+      const { findSimilarCachedQuestion, cacheGeneratedQuestion } =
+        await import('../lib/services/semanticCacheService');
+
+      // Check cache first
+      const cached = await findSimilarCachedQuestion({
+        queryText,
+        questionType,
+        system,
+        difficulty,
+      });
+
+      if (cached) {
+        res.json({
+          success: true,
+          question: cached.question,
+          cached: true,
+          similarity: cached.similarity,
+        });
+      }
+
+      // Generate new question using AI question generation service
+      let newQuestion = null;
+
+      try {
+        const { loadConditionData } = await import('../services/core/conditionDataLoader');
+        const { generateSingleQuestion } = await import('../lib/questionGenerator');
+
+        // Load condition data based on query text
+        const conditionData = await loadConditionData(queryText);
+
+        if (conditionData) {
+          const transformedCondition = {
+            condition: conditionData.condition,
+            sections: {
+              overview: conditionData.content.overview || '',
+              etiology: conditionData.content.etiologyPathophysiology || '',
+              clinicalPresentation: conditionData.content.clinicalPresentation || '',
+              diagnostics: conditionData.content.diagnostics?.notes || '',
+              treatment: (
+                conditionData.content.treatment ||
+                conditionData.content.management ||
+                []
+              ).join('\n'),
+            },
+          };
+
+          // Generate question using AI
+          const generatedQ = await generateSingleQuestion(
+            transformedCondition,
+            questionType as any
+          );
+
+          if (generatedQ) {
+            newQuestion = {
+              ...generatedQ,
+              system: system || conditionData.system,
+              difficulty: difficulty || 'medium',
+              generatedAt: new Date().toISOString(),
+              metadata: {
+                originalQuery: queryText,
+                cached: false,
+              },
+            };
+          }
+        }
+      } catch (generationError) {
+        console.error('Failed to generate question with AI:', generationError);
+      }
+
+      // Fallback if generation failed
+      if (!newQuestion) {
+        newQuestion = {
+          id: `q_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`,
+          type: questionType,
+          system: system || null,
+          difficulty: difficulty || 'medium',
+          text: `Unable to generate question for: ${queryText}. Please try a different condition or query.`,
+          options:
+            questionType === 'mcq' ? ['Option A', 'Option B', 'Option C', 'Option D'] : undefined,
+          correctAnswer: questionType === 'mcq' ? 'Option A' : undefined,
+          explanation: 'Question generation failed. This is a placeholder response.',
+          generatedAt: new Date().toISOString(),
+          metadata: {
+            originalQuery: queryText,
+            cached: false,
+            generationFailed: true,
+          },
+        };
+      }
+
+      // Cache the result
+      await cacheGeneratedQuestion(
+        {
+          queryText,
+          questionType,
+          system,
+          difficulty,
+        },
+        newQuestion
+      );
+
+      res.json({
+        success: true,
+        question: newQuestion,
+        cached: false,
+      });
+    } catch (error) {
+      console.error('Failed to generate question:', error);
+      res.status(500).json({ success: false, error: 'Failed to generate question' });
+    }
+  }
+);
+
+// Seeds Management (Tasks 111)
+
+router.post(
+  '/seeds',
+  validateRequired(['seedData']),
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      if (!process.env.DATABASE_URL) {
+        res.status(503).json({ success: false, error: 'Database not configured' });
+        return;
+      }
+
+      const { createQuestionSeed } = await import('../services/core/questionSeedService');
+      const seed = await createQuestionSeed(req.body.seedData);
+
+      res.json({ success: true, seed });
+    } catch (error) {
+      console.error('Failed to create question seed:', error);
+      res.status(500).json({ success: false, error: 'Failed to create question seed' });
+    }
+  }
+);
+
+router.get('/seeds/:id/assemble', async (req: Request, res: Response): Promise<void> => {
+  try {
+    if (!process.env.DATABASE_URL) {
+      res.status(503).json({ success: false, error: 'Database not configured' });
+      return;
+    }
+
+    const seedId = req.params.id;
+    if (!seedId) {
+      res.status(400).json({ success: false, error: 'Seed id is required' });
+      return;
+    }
+    const { assembleQuestionFromSeed } = await import('../services/core/questionSeedService');
+    const question = await assembleQuestionFromSeed(seedId);
+
+    res.json({ success: true, question });
+  } catch (error) {
+    console.error('Failed to assemble question:', error);
+    res.status(500).json({ success: false, error: 'Failed to assemble question' });
+  }
+});
+
+router.post(
+  '/seeds/assemble',
+  validateRequired(['filter', 'count']),
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      if (!process.env.DATABASE_URL) {
+        res.status(503).json({ success: false, error: 'Database not configured' });
+        return;
+      }
+
+      const { assembleQuestionsFromSeeds } = await import('../services/core/questionSeedService');
+      const { filter, count } = req.body;
+      const questions = await assembleQuestionsFromSeeds(filter, count);
+
+      res.json({ success: true, questions });
+    } catch (error) {
+      console.error('Failed to assemble questions:', error);
+      res.status(500).json({ success: false, error: 'Failed to assemble questions' });
+    }
+  }
+);
+
+router.get('/seeds/stats', async (req: Request, res: Response): Promise<void> => {
+  try {
+    if (!process.env.DATABASE_URL) {
+      res.json({ success: true, stats: {} });
+    }
+
+    const { getSeedStats } = await import('../services/core/questionSeedService');
+    const stats = await getSeedStats();
+
+    res.json({ success: true, stats });
+  } catch (error) {
+    console.error('Failed to get seed stats:', error);
+    res.status(500).json({ success: false, error: 'Failed to get seed stats' });
+  }
+});
+
+export default router;

--- a/routes/recommendations.ts
+++ b/routes/recommendations.ts
@@ -1,0 +1,64 @@
+import { Router, Response } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../lib/middleware/clerkAuth';
+import { recommendationService } from '../lib/services/recommendationService';
+
+const router = Router();
+
+// Get (and generate) recommendations
+router.get('/', requireAuth, async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.auth?.userId;
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    const recommendations = await recommendationService.generateRecommendations(userId);
+    res.json(recommendations);
+  } catch (error) {
+    console.error('Error fetching recommendations:', error);
+    res.status(500).json({ error: 'Failed to fetch recommendations' });
+  }
+});
+
+// Explicit generate trigger
+router.post(
+  '/generate',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const userId = req.auth?.userId;
+      if (!userId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      const recommendations = await recommendationService.generateRecommendations(userId);
+      res.json(recommendations);
+    } catch (error) {
+      console.error('Error generating recommendations:', error);
+      res.status(500).json({ error: 'Failed to generate recommendations' });
+    }
+  }
+);
+
+// Dismiss recommendation
+router.patch(
+  '/:id/dismiss',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const id = req.params.id;
+      const userId = req.auth?.userId;
+      if (!id || !userId) {
+        res.status(401).json({ error: 'Unauthorized or missing id' });
+        return;
+      }
+      await recommendationService.dismissRecommendation(id, userId);
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Error dismissing recommendation:', error);
+      res.status(500).json({ error: 'Failed to dismiss recommendation' });
+    }
+  }
+);
+
+export default router;

--- a/routes/reference.ts
+++ b/routes/reference.ts
@@ -1,0 +1,152 @@
+/**
+ * Reference Data Routes
+ *
+ * Handles all reference data API endpoints (anatomy, special tests, physiology, etc).
+ * Extracted from server.ts for modularity.
+ */
+
+import { Router, Response } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../lib/middleware/clerkAuth';
+
+const router = Router();
+
+// Anatomy
+router.get(
+  '/anatomy',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const { referenceService } = await import('../lib/services/referenceService');
+      const { system, query } = req.query;
+      if (query) {
+        const results = await referenceService.searchAnatomy(query as string);
+        res.json({ success: true, data: results });
+      } else {
+        const results = await referenceService.getAnatomyStructures((system as string) ?? '');
+        res.json({ success: true, data: results });
+      }
+    } catch (error) {
+      console.error('Error fetching anatomy:', error);
+      res.status(500).json({ success: false, error: 'Failed to fetch anatomy' });
+    }
+  }
+);
+
+router.get(
+  '/anatomy/:id',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const { referenceService } = await import('../lib/services/referenceService');
+      const id = req.params.id;
+      if (!id) {
+        res.status(400).json({ success: false, error: 'id is required' });
+        return;
+      }
+      const result = await referenceService.getAnatomyStructure(id);
+      if (!result) {
+        res.status(404).json({ success: false, error: 'Not found' });
+        return;
+      }
+      res.json({ success: true, data: result });
+    } catch (error) {
+      console.error('Error fetching anatomy detail:', error);
+      res.status(500).json({ success: false, error: 'Failed to fetch anatomy detail' });
+    }
+  }
+);
+
+// Special Tests
+router.get('/special-tests', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const { referenceService } = await import('../lib/services/referenceService');
+    const { system } = req.query;
+    const results = await referenceService.getSpecialTests(system as string);
+    res.json({ success: true, data: results });
+  } catch (error) {
+    console.error('Error fetching special tests:', error);
+    res.status(500).json({ success: false, error: 'Failed to fetch special tests' });
+  }
+});
+
+// Physiology
+router.get('/physiology', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const { referenceService } = await import('../lib/services/referenceService');
+    const { category } = req.query;
+    const results = await referenceService.getPhysiologyConcepts(category as string);
+    res.json({ success: true, data: results });
+  } catch (error) {
+    console.error('Error fetching physiology:', error);
+    res.status(500).json({ success: false, error: 'Failed to fetch physiology' });
+  }
+});
+
+// Treatments
+router.get('/treatments', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const { referenceService } = await import('../lib/services/referenceService');
+    const { category } = req.query;
+    const results = await referenceService.getTreatments(category as string);
+    res.json({ success: true, data: results });
+  } catch (error) {
+    console.error('Error fetching treatments:', error);
+    res.status(500).json({ success: false, error: 'Failed to fetch treatments' });
+  }
+});
+
+// Differentials
+router.get('/differentials', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const { referenceService } = await import('../lib/services/referenceService');
+    const { category } = req.query;
+    const results = await referenceService.getDifferentials(
+      category ? { category: category as string } : undefined
+    );
+    res.json({ success: true, data: results });
+  } catch (error) {
+    console.error('Error fetching differentials:', error);
+    res.status(500).json({ success: false, error: 'Failed to fetch differentials' });
+  }
+});
+
+// Imaging
+router.get('/imaging', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const { referenceService } = await import('../lib/services/referenceService');
+    const { modality } = req.query;
+    const results = await referenceService.getImagingStudies(modality as string);
+    res.json({ success: true, data: results });
+  } catch (error) {
+    console.error('Error fetching imaging:', error);
+    res.status(500).json({ success: false, error: 'Failed to fetch imaging' });
+  }
+});
+
+// Findings
+router.get('/findings', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const { referenceService } = await import('../lib/services/referenceService');
+    const { system } = req.query;
+    const results = await referenceService.getFindings(system as string);
+    res.json({ success: true, data: results });
+  } catch (error) {
+    console.error('Error fetching findings:', error);
+    res.status(500).json({ success: false, error: 'Failed to fetch findings' });
+  }
+});
+
+// Guidelines
+router.get('/guidelines', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const { referenceService } = await import('../lib/services/referenceService');
+    const { category } = req.query;
+    const results = await referenceService.getGuidelines(category as string);
+    res.json({ success: true, data: results });
+  } catch (error) {
+    console.error('Error fetching guidelines:', error);
+    res.status(500).json({ success: false, error: 'Failed to fetch guidelines' });
+  }
+});
+
+export default router;

--- a/routes/sync.ts
+++ b/routes/sync.ts
@@ -1,0 +1,269 @@
+/**
+ * Sync Routes
+ *
+ * Handles data synchronization between client and server (offline support).
+ * Extracted from server.ts for modularity.
+ */
+
+import { Router, Response } from 'express';
+import { prisma } from '../lib/prisma';
+import { requireAuth, AuthenticatedRequest } from '../lib/middleware/clerkAuth';
+import { resolveOrCreateQuestionIdentity } from '../lib/study/questionIdentityPersistence';
+import crypto from 'crypto';
+
+const router = Router();
+
+function optionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+async function resolveSavedQuestionIdentityId(
+  tx: unknown,
+  savedQuestion: any
+): Promise<string | null> {
+  const questionId = optionalString(savedQuestion?.questionId);
+  if (!questionId) return null;
+
+  const questionSource = optionalString(savedQuestion?.questionSource) ?? 'question';
+  const sourceQuestionId = optionalString(savedQuestion?.sourceQuestionId) ?? questionId;
+  const canonicalQuestionId =
+    optionalString(savedQuestion?.canonicalQuestionId) ??
+    (questionSource === 'question' ? questionId : null);
+
+  return resolveOrCreateQuestionIdentity(tx, {
+    questionSource,
+    sourceQuestionId,
+    canonicalQuestionId,
+    medicalContentId: optionalString(savedQuestion?.medicalContentId),
+    system: optionalString(savedQuestion?.system),
+    conditionId: optionalString(savedQuestion?.conditionId),
+    provenance: {
+      writer: 'express-sync',
+      type: optionalString(savedQuestion?.type),
+    },
+  });
+}
+
+// API sync endpoint with authentication
+// GET: Fetch user data (PerformanceRecords, SRSItems, SavedQuestions)
+router.get('/', requireAuth, async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.auth?.userId;
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    if (!process.env.DATABASE_URL) {
+      res.json({
+        success: true,
+        data: { performanceRecords: [], srsItems: [], savedQuestions: [] },
+      });
+      return;
+    }
+
+    // Ensure user exists (create if needed) - handles case where Clerk webhook hasn't fired yet
+    const user = await prisma.user.upsert({
+      where: { clerkId: userId },
+      create: {
+        id: crypto.randomUUID(),
+        clerkId: userId,
+        email: '', // Will be updated by Clerk webhook
+        role: 'USER',
+        updatedAt: new Date(),
+      },
+      update: {}, // No-op if user exists
+    });
+
+    const [performanceRecords, srsItems, savedQuestions] = await Promise.all([
+      prisma.performanceRecord.findMany({ where: { userId: user.id } }),
+      prisma.sRSItem.findMany({ where: { userId: user.id } }),
+      prisma.savedQuestion.findMany({ where: { userId: user.id } }),
+    ]);
+
+    // Convert BigInt to Number for JSON serialization
+    const serializedPerformance = performanceRecords.map((r) => ({
+      ...r,
+      timestamp: Number(r.timestamp),
+    }));
+
+    res.json({
+      success: true,
+      data: {
+        performanceRecords: serializedPerformance,
+        srsItems,
+        savedQuestions,
+      },
+    });
+  } catch (error) {
+    console.error('Sync GET error:', error);
+    res.status(500).json({ error: 'Internal server error during sync' });
+  }
+});
+
+// POST: Push local changes to server (PerformanceRecords, SRSItems, SavedQuestions)
+router.post('/', requireAuth, async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.auth?.userId;
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    const { performanceRecords, srsItems, savedQuestions } = req.body;
+
+    if (!process.env.DATABASE_URL) {
+      res.json({ success: true, message: 'Sync acknowledged (No DB configured)' });
+      return;
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { clerkId: userId },
+    });
+
+    if (!user) {
+      res.status(404).json({ error: 'User profile not found. Please log in again.' });
+      return;
+    }
+
+    const internalUserId = user.id;
+
+    await prisma.$transaction(async (tx) => {
+      // 1. Sync Performance Records
+      if (performanceRecords && Array.isArray(performanceRecords)) {
+        for (const record of performanceRecords) {
+          // Deduplication: Check if record exists by timestamp + conditionId
+          const existing = await tx.performanceRecord.findFirst({
+            where: {
+              userId: internalUserId,
+              timestamp: record.timestamp,
+              conditionName: record.conditionName,
+            },
+          });
+
+          if (!existing) {
+            await tx.performanceRecord.create({
+              data: {
+                id: crypto.randomUUID(),
+                userId: internalUserId,
+                topic: record.topic,
+                system: record.system,
+                focus: record.focus,
+                difficulty: record.difficulty,
+                isCorrect: record.isCorrect,
+                timestamp: record.timestamp,
+                questionWordCount: record.questionWordCount,
+                errorTag: record.errorTag,
+                subcategoryName: record.subcategoryName,
+                conditionName: record.conditionName,
+              },
+            });
+          }
+        }
+      }
+
+      // 2. Sync SRS Items
+      if (srsItems && Array.isArray(srsItems)) {
+        for (const item of srsItems) {
+          const now = new Date();
+          await tx.sRSItem.upsert({
+            where: {
+              userId_questionId: {
+                userId: internalUserId,
+                questionId: item.questionId,
+              },
+            },
+            update: {
+              interval: item.interval,
+              repetition: item.repetition,
+              easiness: item.easiness,
+              dueDate: new Date(item.dueDate),
+              lastReviewed: new Date(item.lastReviewed),
+              quality: item.quality,
+              difficulty: item.difficulty,
+              stabilityScore: item.stabilityScore,
+              fsrsStability: item.fsrsStability,
+              fsrsDifficulty: item.fsrsDifficulty,
+              fsrsState: item.fsrsState,
+              fsrsLastReview: item.fsrsLastReview ? new Date(item.fsrsLastReview) : null,
+              updatedAt: now,
+            },
+            create: {
+              id: item.id || crypto.randomUUID(),
+              userId: internalUserId,
+              questionId: item.questionId,
+              interval: item.interval,
+              repetition: item.repetition,
+              easiness: item.easiness,
+              dueDate: new Date(item.dueDate),
+              lastReviewed: new Date(item.lastReviewed),
+              quality: item.quality,
+              difficulty: item.difficulty,
+              stabilityScore: item.stabilityScore,
+              fsrsStability: item.fsrsStability,
+              fsrsDifficulty: item.fsrsDifficulty,
+              fsrsState: item.fsrsState,
+              fsrsLastReview: item.fsrsLastReview ? new Date(item.fsrsLastReview) : null,
+              updatedAt: now,
+            },
+          });
+        }
+      }
+
+      // 3. Sync Saved Questions
+      if (savedQuestions && Array.isArray(savedQuestions)) {
+        for (const sq of savedQuestions) {
+          const now = new Date();
+          const questionIdentityId = await resolveSavedQuestionIdentityId(tx, sq);
+          const identityData = questionIdentityId ? { questionIdentityId } : {};
+          await tx.savedQuestion.upsert({
+            where: {
+              userId_questionId_type: {
+                userId: internalUserId,
+                questionId: sq.questionId,
+                type: sq.type,
+              },
+            },
+            update: {
+              questionText: sq.questionText,
+              correctAnswer: sq.correctAnswer,
+              explanation: sq.explanation,
+              topic: sq.topic,
+              system: sq.system,
+              userNote: sq.userNote,
+              repetitionLevel: sq.repetitionLevel,
+              nextReviewDate: sq.nextReviewDate,
+              ...identityData,
+              updatedAt: now,
+            },
+            create: {
+              id: sq.id || crypto.randomUUID(),
+              userId: internalUserId,
+              questionId: sq.questionId,
+              type: sq.type,
+              questionText: sq.questionText,
+              correctAnswer: sq.correctAnswer,
+              explanation: sq.explanation,
+              topic: sq.topic,
+              system: sq.system,
+              userNote: sq.userNote,
+              repetitionLevel: sq.repetitionLevel,
+              nextReviewDate: sq.nextReviewDate,
+              ...identityData,
+              updatedAt: now,
+            },
+          });
+        }
+      }
+    });
+
+    res.json({
+      success: true,
+      message: 'Data synced successfully',
+    });
+  } catch (error) {
+    console.error('Sync error:', error);
+    res.status(500).json({ error: 'Sync failed' });
+  }
+});
+
+export default router;

--- a/routes/users.ts
+++ b/routes/users.ts
@@ -1,0 +1,141 @@
+/**
+ * User Routes
+ *
+ * Handles user profile, achievements, and simple performance listing.
+ * Complements sync.ts and analytics.ts.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { Router, Request, Response } from 'express';
+import { prisma } from '../lib/prisma';
+import { requireAuth, AuthenticatedRequest } from '../lib/middleware/clerkAuth';
+import crypto from 'crypto';
+
+const router = Router();
+
+// Get User Achievements
+router.get(
+  '/achievements',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const userId = req.auth?.userId;
+      if (!userId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      if (!process.env.DATABASE_URL) {
+        res.json({ success: true, data: [] });
+        return;
+      }
+
+      const user = await prisma.user.findUnique({ where: { clerkId: userId } });
+      if (!user) {
+        res.status(404).json({ error: 'User not found' });
+        return;
+      }
+
+      const achievements = await prisma.userAchievement.findMany({
+        where: { userId: user.id },
+      });
+
+      res.json({ success: true, data: achievements });
+    } catch (error) {
+      console.error('Error fetching achievements:', error);
+      res.status(500).json({ error: 'Failed to fetch achievements' });
+    }
+  }
+);
+
+// Get Performance Records (Simple List)
+router.get(
+  '/performance',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const userId = req.auth?.userId;
+      if (!userId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      if (!process.env.DATABASE_URL) {
+        res.json({ success: true, data: [] });
+        return;
+      }
+
+      const user = await prisma.user.findUnique({ where: { clerkId: userId } });
+      if (!user) {
+        res.status(404).json({ error: 'User not found' });
+        return;
+      }
+
+      const records = await prisma.performanceRecord.findMany({
+        where: { userId: user.id },
+        orderBy: { timestamp: 'desc' },
+        take: 1000,
+      });
+
+      // Convert BigInt to Number for JSON serialization
+      const serializedRecords = records.map((r) => ({
+        ...r,
+        timestamp: Number(r.timestamp),
+      }));
+
+      res.json({ success: true, data: serializedRecords });
+    } catch (error) {
+      console.error('Error fetching performance:', error);
+      res.status(500).json({ error: 'Failed to fetch performance' });
+    }
+  }
+);
+
+// Post Single Performance Record
+router.post(
+  '/performance',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const userId = req.auth?.userId;
+      if (!userId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      const record = req.body;
+
+      if (!process.env.DATABASE_URL) {
+        res.json({ success: true });
+        return;
+      }
+
+      const user = await prisma.user.findUnique({ where: { clerkId: userId } });
+      if (!user) {
+        res.status(404).json({ error: 'User not found' });
+        return;
+      }
+
+      await prisma.performanceRecord.create({
+        data: {
+          id: uuidv4(),
+          userId: user.id,
+          topic: record.topic,
+          system: record.system,
+          focus: record.focus,
+          difficulty: record.difficulty,
+          isCorrect: record.isCorrect,
+          timestamp: record.timestamp,
+          questionWordCount: record.questionWordCount,
+          errorTag: record.errorTag,
+          subcategoryName: record.subcategoryName,
+          conditionName: record.conditionName,
+        },
+      });
+
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Error saving performance:', error);
+      res.status(500).json({ error: 'Failed to save performance' });
+    }
+  }
+);
+
+export default router;

--- a/services/medicalComplianceService.ts
+++ b/services/medicalComplianceService.ts
@@ -739,6 +739,8 @@ export class MedicalComplianceService {
       .find((req) => req.id === requirementId);
 
     if (requirement) {
+      // Stub until review tasks are persisted to the database.
+      void { requirementId, reviewer, dueDate, requirementCode: requirement.code };
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Focused app-code stabilization PR (no new agent infrastructure). Restores missing modules blocking local dev, fixes pre-existing typecheck/lint errors, and documents remaining environment blockers.

## Root causes

1. **Typecheck** — `renderStructuredRationale.ts` indexed `StructuredRationaleInput` with dynamic keys, passing array/object fields to `cleanText(string)`.
2. **Lint** — Empty blocks in `exampleUsage()` and `scheduleReview()` stub after log removal.
3. **`dev:wrangler`** — `functions/api/_shared/semantic-cache.ts` imported `@/lib/services/tokenMatchCache`, which was deleted; `.gitignore` `*token*` pattern also blocked the filename from being tracked.
4. **`dev:server` / `dev:all`** — `routes/` moved to `_trash/old-routes/`; re-export shim failed because trash-relative imports resolved to `_trash/lib/*`.

## Fixes

- Add `getWhyIncorrectText()` exhaustive switch for type-safe distractor field access.
- Replace empty lint blocks with intentional `void` usage (no behavior change).
- Restore `lib/services/tokenMatchCache.ts` + unit tests from git history.
- Restore full `routes/` directory from `_trash/old-routes/` for legacy Express local dev.
- `.gitignore` exceptions for `tokenMatchCache*` and `.cursor/memory/**` docs.

## Validation

| Command | Before | After |
|---------|--------|-------|
| `npm run typecheck` | 2 errors | ✅ PASS |
| `npm run lint` | 3 errors | ✅ PASS (0 errors, 251 warnings) |
| `npm run build` | — | ✅ PASS |
| `npm run test:critical` | — | ✅ 143/143 |
| `npm test` | — | ✅ 9849 passed, 1 skipped |
| `npm run dev:server` | missing `./routes` | ✅ starts with `.env` |
| `npm run dev:wrangler` | missing `tokenMatchCache` | ✅ Worker compiles (needs `DATABASE_URL` at runtime) |

## Remaining blockers (documented in `docs/cursor-followup-issues.md`)

- Local dev requires `.env` with `DATABASE_URL` (cloud agent env has none).
- 251 pre-existing hex-color lint warnings (separate token migration PR).
- Legacy `routes/` vs `functions/api/` drift — production path unchanged.

## Recommended next PRs

1. `.env.example` sync for dev onboarding
2. Legacy routes retirement / dedupe with `_trash/old-routes/`
3. Hex token lint cleanup across pages/types

## Files changed

- `lib/study/renderStructuredRationale.ts`
- `lib/nccpa-question-weighting.ts`
- `services/medicalComplianceService.ts`
- `lib/services/tokenMatchCache.ts` (restored)
- `lib/services/tokenMatchCache.test.ts` (added)
- `routes/*` (restored)
- `.gitignore`
- `docs/cursor-followup-issues.md`
- `.cursor/memory/validation-history.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8a30f4a-f806-4dd2-866f-27f3a4c8984e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8a30f4a-f806-4dd2-866f-27f3a4c8984e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

